### PR TITLE
Fixes build error due to addition of new struct `LVarRef` to r2pipe.rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.swp
 outputs
+*.dot

--- a/src/frontend/containers.rs
+++ b/src/frontend/containers.rs
@@ -278,24 +278,19 @@ fn load_locals(rfn: &mut DefaultFnTy, locals: Option<Vec<LVarInfo>>) {
 
     let locals = locals.expect("This cannot be `None`");
     for l in locals {
-        let ref_str = l.reference.unwrap();
+        let l_ref = l.reference.unwrap();
         let mut operation = "";
-        let operands = &mut [String::new(), String::new()];
-        let mut i = 0;
-        for c in ref_str.chars() {
-            match c {
-                '+' | '-' => {
-                    if c == '+' {
-                        operation = "OpAdd";
-                    } else {
-                        operation = "OpSub";
-                    }
-                    i += 1;
-                }
-                _ => operands[i].push(c),
-            }
+
+        let reg_base = l_ref.base.unwrap();
+        let offset = l_ref.offset.unwrap();
+
+        if offset < 0 {
+            operation = "OpSub";
+        } else {
+            operation = "OpAdd";
         }
-        let postfix_str = format!("({}({}),({}))", operation, operands[0], operands[1]);
+
+        let postfix_str = format!("({}({}),({}))", operation, reg_base, offset);
     }
 }
 


### PR DESCRIPTION
The module tests depend on the pre-analysed example in the `ct1_sccp_ex` folder which needs to be updated according to the current JSON format returned by r2. This will fix broken tests.