### PR TITLE
Clippy refactoring fixes

### DIFF
--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate radeco_lib;
+extern crate radeco_lib;
 extern crate r2pipe;
 
 use std::path::{Path, PathBuf};

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -37,7 +37,7 @@ fn main() {
         ffm = File::create(&fname).expect("Unable to create file");
     }
 
-    for (ref addr, ref mut rfn) in rmod.functions.iter_mut() {
+    for (addr, ref mut rfn) in rmod.functions {
         println!("[+] Analyzing: {} @ {:#x}", rfn.name, addr);
         {
             println!("  [*] Eliminating Dead Code");
@@ -72,5 +72,5 @@ fn main() {
         rmod.src.as_mut().unwrap().send(&format!("CC, {} @ {}", fname.to_str().unwrap(), addr));
     }
 
-    rmod.src.as_mut().unwrap().send(&format!("e scr.color=true"))
+    rmod.src.as_mut().unwrap().send("e scr.color=true")
 }

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -8,8 +8,8 @@ use std::io::Write;
 use r2pipe::r2::R2;
 
 use radeco_lib::frontend::containers::RadecoModule;
-use radeco_lib::analysis::sccp::sccp;
-use radeco_lib::analysis::cse::cse::CSE;
+use radeco_lib::analysis::sccp;
+use radeco_lib::analysis::cse::CSE;
 use radeco_lib::middle::{dce};
 use radeco_lib::middle::ir_writer::IRWriter;
 

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -10,7 +10,7 @@ use r2pipe::r2::R2;
 use radeco_lib::frontend::containers::RadecoModule;
 use radeco_lib::analysis::sccp;
 use radeco_lib::analysis::cse::CSE;
-use radeco_lib::middle::{dce};
+use radeco_lib::middle::dce;
 use radeco_lib::middle::ir_writer::IRWriter;
 
 fn main() {

--- a/src/analysis/cse.rs
+++ b/src/analysis/cse.rs
@@ -31,7 +31,7 @@ where I: Iterator<Item = S::ValueRef>,
         }
     }
 
-    fn hash_args(&self, args: &Vec<S::ValueRef>) -> String {
+    fn hash_args(&self, args: &[S::ValueRef]) -> String {
         let mut result = String::new();
         for arg in args {
             if let Ok(node_data) = self.ssa.get_node_data(arg) {
@@ -86,7 +86,7 @@ where I: Iterator<Item = S::ValueRef>,
                     // restrict outselves to the case where both the expressions belong to the same
                     // block.
                     for ex_idx in &ex_idxs {
-                        if self.ssa.block_of(&ex_idx) == self.ssa.block_of(&expr) {
+                        if self.ssa.block_of(ex_idx) == self.ssa.block_of(&expr) {
                             self.ssa.replace(expr, *ex_idx);
                             replaced = true;
                             break;
@@ -97,11 +97,11 @@ where I: Iterator<Item = S::ValueRef>,
 
             if !replaced {
                 if let Some(ref hs0) = hashes[0] {
-                    self.exprs.entry(hs0.clone()).or_insert(Vec::new()).push(expr);
+                    self.exprs.entry(hs0.clone()).or_insert_with(Vec::new).push(expr);
                     self.hashed.insert(expr, hs0.clone());
                 }
                 if let Some(ref hs1) = hashes[1] {
-                    self.exprs.entry(hs1.clone()).or_insert(Vec::new()).push(expr);
+                    self.exprs.entry(hs1.clone()).or_insert_with(Vec::new).push(expr);
                 }
             }
         }

--- a/src/analysis/cse/cse.rs
+++ b/src/analysis/cse/cse.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
-use middle::ssa::ssa_traits::{NodeData, NodeType, SSA, SSAMod, SSAWalk};
+use middle::ssa::ssa_traits::{NodeType, SSA, SSAMod, SSAWalk};
 use middle::ir::MOpcode;
 
 #[derive(Debug)]

--- a/src/analysis/dom/domtree.rs
+++ b/src/analysis/dom/domtree.rs
@@ -10,8 +10,7 @@
 use std::default;
 use std::collections::{HashMap, HashSet};
 use petgraph::graph::Graph;
-use petgraph::graph;
-use petgraph::EdgeDirection;
+use petgraph::{graph, EdgeDirection};
 
 use middle::dot::{DotAttrBlock, GraphDot};
 use super::index::InternalIndex;

--- a/src/analysis/dom/domtree.rs
+++ b/src/analysis/dom/domtree.rs
@@ -215,8 +215,8 @@ impl DomTree {
                 "Call to DomTree::doms before 
 									  DomTree::build_dom_tree.");
 
-        let internal_index = self.rmap.get(&i).unwrap();
-        let mut idom = *internal_index;
+        let internal_index = self.rmap[&i];
+        let mut idom = internal_index;
         let mut doms = Vec::<InternalIndex>::new();
         while idom != self.idom[idom] {
             doms.push(idom);
@@ -232,8 +232,8 @@ impl DomTree {
                 "Call to DomTree::idom before 
 				DomTree::build_dom_tree.");
 
-        let internal_index = self.rmap.get(&i).unwrap();
-        let internal_node = self.idom[*internal_index];
+        let internal_index = self.rmap[&i];
+        let internal_node = self.idom[internal_index];
         internal_node.external()
     }
 
@@ -267,9 +267,9 @@ impl DomTree {
             let node_count = g.node_count();
 
             // compute postorder numbering.
-            v.dfs(&g, start_node);
+            v.dfs(g, start_node);
             for i in 0..node_count {
-                v.dfs(&g, graph::NodeIndex::new(i));
+                v.dfs(g, graph::NodeIndex::new(i));
             }
 
             // Tuple of (graph::NodeIndex, post-order numbering).
@@ -312,7 +312,7 @@ impl DomTree {
                     let preds_iter = g.neighbors_directed(node, EdgeDirection::Incoming)
                                       .map(|x| rmap.get(&x).unwrap());
                     let preds = preds_map.entry(node)
-                                         .or_insert(preds_iter.cloned().collect::<Vec<_>>());
+                                         .or_insert_with(|| preds_iter.cloned().collect::<Vec<_>>());
                     let mut new_idom = invalid_index;
                     for p in preds.iter() {
                         if idom[*p] < invalid_index {
@@ -321,10 +321,10 @@ impl DomTree {
                         }
                     }
                     // Make sure we found a node.
-                    assert!(new_idom != invalid_index);
+                    assert_ne!(new_idom, invalid_index);
                     for p in preds.iter() {
                         if idom[*p] != invalid_index {
-                            new_idom = DomTree::intersect(&idom, &new_idom, p);
+                            new_idom = DomTree::intersect(idom, &new_idom, p);
                         }
                     }
                     if idom[n.1] != new_idom {
@@ -354,8 +354,8 @@ impl DomTree {
         let node_count = self.idom.len();
         let mut frontier_map = HashMap::<graph::NodeIndex, HashSet<graph::NodeIndex>>::new();
         for node in (0..node_count).map(graph::NodeIndex::new) {
-            let internal_index = self.rmap.get(&node).unwrap();
-            let preds = self.preds_map.get(&node).unwrap();
+            let internal_index = self.rmap[&node];
+            let preds = &self.preds_map[&node];
 
             if preds.len() < 2 {
                 continue;
@@ -363,7 +363,7 @@ impl DomTree {
 
             for p in preds {
                 let mut runner = *p;
-                while runner != self.idom[*internal_index] {
+                while runner != self.idom[internal_index] {
                     let runner_index = runner.external();
                     frontier_map.entry(runner_index).or_insert_with(HashSet::new).insert(node);
 
@@ -376,8 +376,8 @@ impl DomTree {
     }
 
     pub fn dom_frontier(&self, n: graph::NodeIndex) -> HashSet<graph::NodeIndex> {
-        assert!(self.dom_frontier != None, "Uninitialized dom_frontier.");
-        self.dom_frontier.clone().unwrap().get(&n).unwrap().clone()
+        assert_ne!(self.dom_frontier, None, "Uninitialized dom_frontier.");
+        self.dom_frontier.clone().unwrap()[&n].clone()
     }
 }
 

--- a/src/analysis/interproc/interproc.rs
+++ b/src/analysis/interproc/interproc.rs
@@ -1,9 +1,8 @@
 //! Fills out the call summary information for `RFunction`
 
 use std::collections::HashSet;
-use std::marker::PhantomData;
 use analysis::interproc::transfer::InterProcAnalysis;
-use frontend::containers::{RFunction, RModule};
+use frontend::containers::{RModule};
 
 #[derive(Debug)]
 pub struct InterProcAnalyzer<'a, 'b, M, T>
@@ -66,15 +65,11 @@ impl<'a,'b, M, T> InterProcAnalyzer<'a, 'b, M, T>
 #[cfg(test)]
 mod test {
     use super::*;
-    use frontend::source::{FileSource, Source};
+    use frontend::source::FileSource;
     use frontend::containers::*;
-    use petgraph::graph::NodeIndex;
-    use frontend::bindings::*;
     use middle::ir_writer::IRWriter;
-    use std::io;
     use middle::dce;
     use analysis::interproc::summary;
-    use r2pipe::r2::R2;
 
     #[test]
     fn ipa_t1() {

--- a/src/analysis/interproc/interproc.rs
+++ b/src/analysis/interproc/interproc.rs
@@ -15,8 +15,8 @@ pub struct InterProcAnalyzer<'a, 'b, M, T>
 }
 
 pub fn analyze_module<'a, 'b, M, A>(ssa: &'a mut M) 
-where M: RModule<'b>,
-      A: InterProcAnalysis<'b, M> {
+    where M: RModule<'b>,
+          A: InterProcAnalysis<'b, M> {
     let mut ipa = InterProcAnalyzer::<M, A>::new(ssa);
     for f in &ipa.rmod.functions() {
         ipa.analyze_function(f);

--- a/src/analysis/interproc/interproc.rs
+++ b/src/analysis/interproc/interproc.rs
@@ -66,10 +66,12 @@ impl<'a,'b, M, T> InterProcAnalyzer<'a, 'b, M, T>
 mod test {
     use super::*;
     use frontend::source::FileSource;
+    // use frontend::source::Source;
     use frontend::containers::*;
     use middle::ir_writer::IRWriter;
     use middle::dce;
     use analysis::interproc::summary;
+    // use r2pipe::r2::R2;
 
     #[test]
     fn ipa_t1() {

--- a/src/analysis/interproc/interproc.rs
+++ b/src/analysis/interproc/interproc.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 use analysis::interproc::transfer::InterProcAnalysis;
-use frontend::containers::{RModule};
+use frontend::containers::RModule;
 
 #[derive(Debug)]
 pub struct InterProcAnalyzer<'a, 'b, M, T>

--- a/src/analysis/interproc/mod.rs
+++ b/src/analysis/interproc/mod.rs
@@ -5,21 +5,6 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Module that implements analysis and optimizations on radeco IR.
-
-#[allow(dead_code)]
-pub mod valueset;
-// pub mod propagate;
-pub mod dom;
-pub mod sccp;
-pub mod cse;
-
-#[macro_use]
-pub mod matcher {
-    #[macro_use]
-    pub mod gmatch;
-}
-
+pub mod summary;
 pub mod interproc;
-
-pub mod tie;
+pub mod transfer;

--- a/src/analysis/interproc/summary.rs
+++ b/src/analysis/interproc/summary.rs
@@ -10,12 +10,12 @@ use middle::ssa::ssa_traits::{SSA, NodeType};
 use middle::ssa::cfg_traits::{CFG};
 use middle::ir::MOpcode;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct CallSummary { }
 
 impl<'a, T: RModule<'a>> InterProcAnalysis<'a, T> for CallSummary {
     fn new() -> CallSummary {
-        CallSummary { }
+        Default::default()
     }
 
     // Compute fn arguments, modifides and returns lists.
@@ -92,9 +92,9 @@ impl<'a, T: RModule<'a>> InterProcAnalysis<'a, T> for CallSummary {
                 }
             }
 
-            rfn.set_returns(&returns.into_iter().map(|x| From::from(x)).collect::<Vec<_>>());
-            rfn.set_modifides(&modifides.into_iter().map(|x| From::from(x)).collect::<Vec<_>>());
-            rfn.set_args(&args.into_iter().map(|x| From::from(x)).collect::<Vec<_>>());
+            rfn.set_returns(&returns.into_iter().map(From::from).collect::<Vec<_>>());
+            rfn.set_modifides(&modifides.into_iter().map(From::from).collect::<Vec<_>>());
+            rfn.set_args(&args.into_iter().map(From::from).collect::<Vec<_>>());
         }
     }
 

--- a/src/analysis/interproc/summary.rs
+++ b/src/analysis/interproc/summary.rs
@@ -7,7 +7,7 @@ use petgraph::graph::NodeIndex;
 use analysis::interproc::transfer::InterProcAnalysis;
 use frontend::containers::{RModule, RFunction};
 use middle::ssa::ssa_traits::{SSA, NodeType};
-use middle::ssa::cfg_traits::{CFG};
+use middle::ssa::cfg_traits::CFG;
 use middle::ir::MOpcode;
 
 #[derive(Clone, Debug, Default)]

--- a/src/analysis/interproc/summary.rs
+++ b/src/analysis/interproc/summary.rs
@@ -5,11 +5,9 @@ use std::collections::HashSet;
 use petgraph::graph::NodeIndex;
 
 use analysis::interproc::transfer::InterProcAnalysis;
-use analysis::matcher::gmatch;
-use frontend::containers::{RModule, RFunction, CallContext};
-use frontend::bindings::RBindings;
-use middle::ssa::ssa_traits::{SSA, SSAMod, NodeType, SSAWalk};
-use middle::ssa::cfg_traits::{CFG, CFGMod};
+use frontend::containers::{RModule, RFunction};
+use middle::ssa::ssa_traits::{SSA, NodeType};
+use middle::ssa::cfg_traits::{CFG};
 use middle::ir::MOpcode;
 
 #[derive(Clone, Debug)]

--- a/src/analysis/interproc/transfer.rs
+++ b/src/analysis/interproc/transfer.rs
@@ -1,6 +1,6 @@
 //! Defines transfer and propagate traits used for interprocess analysis.
 
-use frontend::containers::{RModule};
+use frontend::containers::RModule;
 
 pub trait InterProcAnalysis<'a, T: RModule<'a>> {
     fn new() -> Self;

--- a/src/analysis/interproc/transfer.rs
+++ b/src/analysis/interproc/transfer.rs
@@ -1,6 +1,6 @@
 //! Defines transfer and propagate traits used for interprocess analysis.
 
-use frontend::containers::{RModule, RFunction};
+use frontend::containers::{RModule};
 
 pub trait InterProcAnalysis<'a, T: RModule<'a>> {
     fn new() -> Self;

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -400,7 +400,7 @@ mod test {
     use analysis::matcher::gmatch;
     use middle::ssa::ssastorage::{SSAStorage, NodeData};
     use middle::ssa::ssa_traits::{SSA, SSAMod, ValueType, SSAWalk};
-    use middle::ssa::cfg_traits::{CFGMod};
+    use middle::ssa::cfg_traits::CFGMod;
     use middle::ir::{MOpcode, MAddress};
 
     #[test]

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -228,7 +228,7 @@ where I: Iterator<Item=S::ValueRef>,
                 }
 
                 let current = t.current().unwrap();
-                if current.starts_with("%") {
+                if current.starts_with('%') {
                     // Match the current subtree to the subtree bound by the variable before. If
                     // they do not match, then report as mismatch.
                     let subtreeh = self.hash_subtree(inner_node);
@@ -251,7 +251,7 @@ where I: Iterator<Item=S::ValueRef>,
                 // All the cases which can cause a mismatch in the node and it's arguments.
                 // Since "%" binds the entire subtree, it will not have any arguments. So we skip
                 // this case.
-                if args.len() != t.len() && !current.starts_with("%") {
+                if args.len() != t.len() && !current.starts_with('%') {
                     viable = false;
                     break;
                 }
@@ -355,7 +355,7 @@ where I: Iterator<Item=S::ValueRef>,
             t_
         };
 
-        let replace_root = if r.current().as_ref().unwrap().starts_with("%") {
+        let replace_root = if r.current().as_ref().unwrap().starts_with('%') {
             *bindings.get(r.current().as_ref().unwrap()).expect("Unknown Binding")
         } else {
             self.map_token_to_node(r.current().as_ref().unwrap(),
@@ -377,7 +377,7 @@ where I: Iterator<Item=S::ValueRef>,
                 t_
             };
             let current = pt.current().unwrap();
-            let inner_node = if current.starts_with("%") {
+            let inner_node = if current.starts_with('%') {
                 *bindings.get(&current).expect("Unknown Binding")
             } else {
                 self.map_token_to_node(&current, &block, &mut address)

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -397,15 +397,11 @@ where I: Iterator<Item=S::ValueRef>,
 #[cfg(test)]
 mod test {
     use super::*;
-    use petgraph::graph::NodeIndex;
     use analysis::matcher::gmatch;
-    use std::io::prelude::*;
-    use std::io;
     use middle::ssa::ssastorage::{SSAStorage, NodeData};
     use middle::ssa::ssa_traits::{SSA, SSAMod, ValueType, SSAWalk};
-    use middle::ssa::cfg_traits::{CFG, CFGMod};
+    use middle::ssa::cfg_traits::{CFGMod};
     use middle::ir::{MOpcode, MAddress};
-    use middle::ir_writer::IRWriter;
 
     #[test]
     fn parse_expr() {

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -411,7 +411,7 @@ mod test {
     fn parse_expr() {
         let mut ssa = SSAStorage::new();
         let find_pat = "(OpXor %1, %1)".to_owned();
-        let mut matcher = GraphMatcher::new(&mut ssa);
+        let matcher = GraphMatcher::new(&mut ssa);
         let t = matcher.parse_expression(&find_pat);
         assert_eq!(Some("OpXor".to_owned()), t.current());
         assert_eq!(Some("%1".to_owned()), t.lhs());
@@ -422,7 +422,7 @@ mod test {
     fn parse_expr1() {
         let mut ssa = SSAStorage::new();
         let find_pat = "(EEq eax, (EAdd eax, (EAdd eax, cf)))".to_owned();
-        let mut matcher = GraphMatcher::new(&mut ssa);
+        let matcher = GraphMatcher::new(&mut ssa);
         let t = matcher.parse_expression(&find_pat);
         assert_eq!(Some("EEq".to_owned()), t.current());
         assert_eq!(Some("eax".to_owned()), t.lhs());
@@ -433,7 +433,7 @@ mod test {
     fn parse_expr2() {
         let mut ssa = SSAStorage::new();
         let find_pat = "(EAdd (EAdd eax, of), (EAdd eax, cf))".to_owned();
-        let mut matcher = GraphMatcher::new(&mut ssa);
+        let matcher = GraphMatcher::new(&mut ssa);
         let t = matcher.parse_expression(&find_pat);
         assert_eq!(Some("EAdd".to_owned()), t.current());
         assert_eq!(Some("(EAdd eax, of)".to_owned()), t.lhs());
@@ -444,7 +444,7 @@ mod test {
     fn parse_expr_unary() {
         let mut ssa = SSAStorage::new();
         let find_pat = "(OpNot rax)".to_owned();
-        let mut matcher = GraphMatcher::new(&mut ssa);
+        let matcher = GraphMatcher::new(&mut ssa);
         let t = matcher.parse_expression(&find_pat);
         assert_eq!(Some("OpNot".to_owned()), t.current());
         assert_eq!(Some("rax".to_owned()), t.lhs());
@@ -455,7 +455,7 @@ mod test {
     fn parse_expr_ternary() {
         let mut ssa = SSAStorage::new();
         let find_pat = "(OpStore %1, %2, %3)".to_owned();
-        let mut matcher = GraphMatcher::new(&mut ssa);
+        let matcher = GraphMatcher::new(&mut ssa);
         let t = matcher.parse_expression(&find_pat);
         assert_eq!(Some("OpStore".to_owned()), t.current());
         assert_eq!(Some("%1".to_owned()), t.lhs());

--- a/src/analysis/sccp.rs
+++ b/src/analysis/sccp.rs
@@ -107,8 +107,8 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
 
         let parent_block = self.g.get_block(i);
         for op in &operands {
-            let operand_block = self.g.get_block(&op);
-            let op_val = self.get_value(&op);
+            let operand_block = self.g.get_block(op);
+            let op_val = self.get_value(op);
 
             if op_val.is_undefined() {
                 continue;
@@ -451,7 +451,7 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
         if !self.g.is_expr(i) {
             return;
         }
-        let owner_block = self.g.get_block(&i);
+        let owner_block = self.g.get_block(i);
         if self.is_block_executable(&owner_block) {
             self.ssa_worklist.push_back(*i);
         }

--- a/src/analysis/sccp/sccp.rs
+++ b/src/analysis/sccp/sccp.rs
@@ -16,7 +16,6 @@ use std::collections::{HashMap, VecDeque};
 use middle::ssa::ssa_traits::{SSA, SSAMod};
 use middle::ssa::ssa_traits::NodeType;
 use middle::ir::{MArity, MOpcode};
-use middle::ssa::cfg_traits::CFG;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum LatticeValue {

--- a/src/analysis/tie/structs.rs
+++ b/src/analysis/tie/structs.rs
@@ -123,7 +123,7 @@ pub enum SubTypeEdge {
     SubType,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SubTypeSet {
     g: Graph<SubTypeNode, SubTypeEdge>,
     // Map from NodeIndex in ConstraintSet to NodeIndex in SubTypeSet.
@@ -131,13 +131,6 @@ pub struct SubTypeSet {
 }
 
 impl SubTypeSet {
-    pub fn new() -> SubTypeSet {
-        SubTypeSet {
-            g: Graph::new(),
-            map: HashMap::new(),
-        }
-    }
-
     // Insert LHS <: RHS
     pub fn insert_relation(&mut self, lhs: &NodeIndex, rhs: &NodeIndex) {
         let sub_lhs = if let Some(idx) = self.map.get(lhs).cloned() {
@@ -189,7 +182,7 @@ impl SubTypeSet {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ConstraintSet {
     g: Graph<ConstraintNode, ConstraintEdge>,
     type_vars: HashMap<String, NodeIndex>,
@@ -204,16 +197,6 @@ pub struct ConstraintSet {
 }
 
 impl ConstraintSet {
-    pub fn new() -> ConstraintSet {
-        ConstraintSet {
-            g: Graph::new(),
-            type_vars: HashMap::new(),
-            subty: SubTypeSet::new(),
-            binding_map: HashMap::new(),
-            upper_bound: HashMap::new(),
-            lower_bound: HashMap::new(),
-        }
-    }
 
     pub fn operands(&self, n: &NodeIndex) -> Vec<NodeIndex> {
         let mut result = Vec::new();

--- a/src/analysis/tie/structs.rs
+++ b/src/analysis/tie/structs.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::collections::HashMap;
 
-use petgraph::graph::{EdgeIndex, Graph, NodeIndex, EdgeReference};
+use petgraph::graph::{EdgeIndex, Graph, NodeIndex};
 use petgraph::visit::{EdgeRef};
 use petgraph::EdgeDirection;
 

--- a/src/analysis/tie/structs.rs
+++ b/src/analysis/tie/structs.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::collections::HashMap;
 
 use petgraph::graph::{EdgeIndex, Graph, NodeIndex};
-use petgraph::visit::{EdgeRef};
+use petgraph::visit::EdgeRef;
 use petgraph::EdgeDirection;
 
 type TIEResult<T> = Result<T, String>;

--- a/src/backend/lang_c/c_ast_constructor.rs
+++ b/src/backend/lang_c/c_ast_constructor.rs
@@ -54,7 +54,7 @@ impl CWriter {
     /// Converts all the functions inside the current RModule to CAST and
     /// stores it internally. This can later be emitted.
     pub fn rmod_to_c_ast<'a, M: RModule<'a>>(&mut self, rmod: &M) {
-        for rfn_idx in rmod.functions().iter() {
+        for ref rfn_idx in rmod.functions() {
             if let Some(rfn) = rmod.function_by_ref(rfn_idx) {
                 let fn_ref: u64 = (*rfn_idx).into();
                 self.rfn_to_c_ast(rfn, fn_ref);
@@ -69,7 +69,7 @@ impl CWriter {
 
     /// Emit C code for all the functions that the current C-Emitter contains.
     pub fn emit<T>(&self, w: &mut T) where T: Write {
-        for (_, c) in self.c_ast.iter() {
+        for c in self.c_ast.values() {
             write!(w, "{}\n", c.print());
         }
     }

--- a/src/backend/lang_c/c_ast_constructor.rs
+++ b/src/backend/lang_c/c_ast_constructor.rs
@@ -78,6 +78,8 @@ impl CWriter {
 #[cfg(test)]
 mod test {
     use super::*;
+    // use frontend::containers::RadecoFunction;
+    // use frontend::source::FileSource;
     use frontend::containers::RadecoModule;
     use middle::dce;
     use analysis::interproc::interproc::analyze_module;

--- a/src/backend/lang_c/c_ast_constructor.rs
+++ b/src/backend/lang_c/c_ast_constructor.rs
@@ -78,11 +78,8 @@ impl CWriter {
 #[cfg(test)]
 mod test {
     use super::*;
-    use frontend::containers::{RadecoModule, RadecoFunction};
-    use frontend::source::FileSource;
-    use std::io;
+    use frontend::containers::RadecoModule;
     use middle::dce;
-    use std::io::prelude::*;
     use analysis::interproc::interproc::analyze_module;
     use analysis::interproc::summary;
     use r2pipe::r2::R2;

--- a/src/backend/lang_c/c_simple.rs
+++ b/src/backend/lang_c/c_simple.rs
@@ -4,11 +4,9 @@
 //! stages maybe added to
 //! make the decompiled output easier to read and add more sugaring.
 
-use std::default;
-use std::iter;
-use std::fmt;
+use std::{default, iter, fmt};
 
-use petgraph::graph::{Graph, NodeIndex, EdgeIndex, EdgeReference};
+use petgraph::graph::{Graph, NodeIndex, EdgeIndex};
 use petgraph::visit::{EdgeRef};
 use petgraph::EdgeDirection;
 

--- a/src/backend/lang_c/c_simple.rs
+++ b/src/backend/lang_c/c_simple.rs
@@ -7,7 +7,7 @@
 use std::{default, iter, fmt};
 
 use petgraph::graph::{Graph, NodeIndex, EdgeIndex};
-use petgraph::visit::{EdgeRef};
+use petgraph::visit::EdgeRef;
 use petgraph::EdgeDirection;
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/backend/lang_c/c_simple.rs
+++ b/src/backend/lang_c/c_simple.rs
@@ -366,7 +366,7 @@ impl CAST {
                         format_with_indent("}", indent))
             }
             CASTNode::Declaration(ref ty) => {
-                let mut ty = format_with_indent(&ty.to_string(), indent);
+                let ty = format_with_indent(&ty.to_string(), indent);
                 let mut vars = String::new();
                 for op in self.ast.edges_directed(*node, EdgeDirection::Outgoing) {
                     if let CASTNode::Var(ref name) = self.ast[op.target()] {

--- a/src/frontend/bindings.rs
+++ b/src/frontend/bindings.rs
@@ -43,7 +43,7 @@ pub trait RBind {
     fn is_unknown(&self) -> bool;
 
     fn add_refs(&mut self, Vec<Self::SSARef>);
-    fn refs<'a>(&'a self) -> ::std::slice::Iter<'a, Self::SSARef>;
+    fn refs(&self) -> ::std::slice::Iter<Self::SSARef>;
 }
 
 /// Trait that describes variable bindings for a function.
@@ -85,13 +85,13 @@ pub struct RadecoBindings<T: RBind> {
 
 impl<BTy: RBind> Index<usize> for RadecoBindings<BTy> {
     type Output = BTy;
-    fn index<'a>(&'a self, index: usize) -> &'a Self::Output {
+    fn index(&self, index: usize) -> &Self::Output {
         self.binding(&index).unwrap()
     }
 }
 
 impl<BTy: RBind> IndexMut<usize> for RadecoBindings<BTy> {
-    fn index_mut<'a>(&'a mut self, index: usize) -> &'a mut Self::Output {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         self.binding_mut(&index).unwrap()
     }
 }
@@ -256,7 +256,7 @@ impl<T: Clone + fmt::Debug> RBind for Binding<T> {
 
     fn is_register(&self) -> bool {
         match self.vloc {
-            VarLocation::Register { name: _ } => true,
+            VarLocation::Register { .. } => true,
             _ => false,
         }
     }
@@ -271,7 +271,7 @@ impl<T: Clone + fmt::Debug> RBind for Binding<T> {
 
     fn is_fn_local(&self) -> bool {
         match self.vloc {
-            VarLocation::Memory(MemoryRegion::FunctionLocal { base: _, offset: _ }) => true,
+            VarLocation::Memory(MemoryRegion::FunctionLocal { .. }) => true,
             _ => false,
         }
     }
@@ -336,7 +336,7 @@ impl<T: Clone + fmt::Debug> RBind for Binding<T> {
         self.ssa_refs.extend(refs);
     }
 
-    fn refs<'a>(&'a self) -> ::std::slice::Iter<'a, T> {
+    fn refs(&self) -> ::std::slice::Iter<T> {
         self.ssa_refs.iter()
     }
 }

--- a/src/frontend/containers.rs
+++ b/src/frontend/containers.rs
@@ -102,7 +102,7 @@ impl<B: RBindings> RadecoFunction<B> {
     pub fn construct(reg_profile: &LRegInfo, insts: Vec<LOpInfo>) -> RadecoFunction<B> {
         let mut rfn = RadecoFunction::new();
         {
-            let mut constructor = SSAConstruct::new(&mut rfn.ssa, &reg_profile);
+            let mut constructor = SSAConstruct::new(&mut rfn.ssa, reg_profile);
             constructor.run(insts);
         }
         rfn
@@ -286,7 +286,7 @@ fn analyze_memory(rfn: &mut DefaultFnTy) {
         }
     }
 
-    for b in seen_l.values().into_iter() {
+    for b in seen_l.values() {
         rfn.bindings.insert(b.clone());
     }
 
@@ -442,7 +442,7 @@ impl<'a, F: RFunction> RModule<'a> for RadecoModule<'a, F> {
 
     fn callees_of(&self, fref: &Self::FnRef) -> Vec<Self::FnRef> {
         let mut callees = Vec::<Self::FnRef>::new();
-        if let Some(ref c) = self.functions.get(fref) {
+        if let Some(c) = self.functions.get(fref) {
             callees.extend(c.callrefs().iter().cloned().map(Self::FnRef::from));
         }
         callees
@@ -450,7 +450,7 @@ impl<'a, F: RFunction> RModule<'a> for RadecoModule<'a, F> {
 
     fn callers_of(&self, fref: &Self::FnRef) -> Vec<Self::FnRef> {
         let mut callers = Vec::<Self::FnRef>::new();
-        if let Some(ref c) = self.functions.get(fref) {
+        if let Some(c) = self.functions.get(fref) {
             callers.extend(c.callxrefs().iter().cloned().map(Self::FnRef::from));
         }
         callers
@@ -537,7 +537,7 @@ impl<B: RBindings> RFunction for RadecoFunction<B> {
 
     fn set_locals(&mut self, locals: &[(<Self::B as RBindings>::Idx, LocalInfo)]) {
         for &(ref arg, ref info) in locals {
-            if let Some(binding) = self.bindings.binding_mut(&arg) {
+            if let Some(binding) = self.bindings.binding_mut(arg) {
                 binding.mark_fn_local(info.base, info.offset);
             }
         }

--- a/src/frontend/source.rs
+++ b/src/frontend/source.rs
@@ -1,6 +1,6 @@
 //! Defines the `Source` Trait.
 
-use std::path::{self, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 

--- a/src/frontend/source.rs
+++ b/src/frontend/source.rs
@@ -79,7 +79,7 @@ impl Source for R2 {
 
     fn instructions_at(&mut self, address: u64) -> Vec<LOpInfo> {
         if let Ok(fn_info) = self.function(&format!("{}", address)) {
-            fn_info.ops.unwrap_or(Vec::new())
+            fn_info.ops.unwrap_or_default()
         } else {
             Vec::new()
         }
@@ -135,8 +135,8 @@ impl FileSource {
         let mut path = PathBuf::from(&self.dir);
         path.push(&format!("{}_{}.json", self.base_name, suffix));
         let mut f = File::create(path).expect("Failed to open file");
-        let _ = f.write_all(data.to_string()
-                                .as_bytes()).expect("Failed to read file");
+        f.write_all(data.to_string()
+                        .as_bytes()).expect("Failed to read file");
     }
 }
 

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -102,7 +102,7 @@ impl<'a, T> SSAConstruct<'a, T>
     }
 
     fn mem_id(&self) -> usize {
-        assert!(self.mem_id != 0);
+        assert_ne!(self.mem_id, 0);
         self.mem_id
     }
 
@@ -155,7 +155,7 @@ impl<'a, T> SSAConstruct<'a, T>
         // this function should return `None`.
         // NB 2: We never write to an intermediate twice as this is an SSA form!
         if let Some(ref res) = result {
-            self.intermediates.push(res.clone());
+            self.intermediates.push(*res);
             let result_id = self.intermediates.len() - 1;
             let out_size = self.phiplacer.operand_width(res);
             Some(Token::EEntry(result_id, Some(out_size as u64)))
@@ -218,7 +218,7 @@ impl<'a, T> SSAConstruct<'a, T>
                         }
                     } else {
                         // We are writing into a register.
-                        self.phiplacer.write_register(address, &name, rhs.expect("rhs for EEq cannot be `None`"));
+                        self.phiplacer.write_register(address, name, rhs.expect("rhs for EEq cannot be `None`"));
                     }
                 } else {
                     // This means that we're performing a memory write. So we need to emit an
@@ -509,7 +509,7 @@ mod test {
     use middle::ssa::ssastorage::SSAStorage;
     use middle::ir_writer::IRWriter;
     use middle::{dot, dce};
-    use analysis::sccp::sccp;
+    use analysis::sccp;
 
 
     const REGISTER_PROFILE: &'static str = "test_files/x86_register_profile.json";

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -14,9 +14,7 @@
 
 use std::collections::HashMap;
 use petgraph::graph::NodeIndex;
-use std::fmt::Debug;
-use std::cmp::Ordering;
-use std::cmp;
+use std::{fmt, cmp};
 
 use r2pipe::structs::{LOpInfo, LRegInfo};
 
@@ -35,7 +33,7 @@ const TRUE_EDGE: u8 = 1;
 const UNCOND_EDGE: u8 = 2;
 
 pub struct SSAConstruct<'a, T>
-    where T: 'a + Clone + Debug + SSAMod<BBInfo = MAddress> + SSAExtra
+    where T: 'a + Clone + fmt::Debug + SSAMod<BBInfo = MAddress> + SSAExtra
 {
     phiplacer: PhiPlacer<'a, T>,
     regfile: SubRegisterFile,
@@ -57,7 +55,7 @@ pub struct SSAConstruct<'a, T>
 
 impl<'a, T> SSAConstruct<'a, T>
     where T: 'a + Clone
-    + Debug
+    + fmt::Debug
     + SSAExtra
     + SSAMod<BBInfo=MAddress, ValueRef=NodeIndex, ActionRef=NodeIndex>
 {
@@ -341,21 +339,21 @@ impl<'a, T> SSAConstruct<'a, T>
         // Insert `widen` cast of the two are not of same size and rhs is_some.
         if rhs.is_some() {
             let (lhs, rhs) = match lhs_size.cmp(&rhs_size) {
-                Ordering::Greater => {
+                cmp::Ordering::Greater => {
                     let vt = ValueType::Integer { width: lhs_size };
                     let casted_rhs = self.phiplacer
                                          .add_op(&MOpcode::OpWiden(lhs_size), address, vt);
                     self.phiplacer.op_use(&casted_rhs, 0, rhs.as_ref().expect(""));
                     (lhs.expect("lhs cannot be `None`"), casted_rhs)
                 }
-                Ordering::Less => {
+                cmp::Ordering::Less => {
                     let vt = ValueType::Integer { width: rhs_size };
                     let casted_lhs = self.phiplacer
                                          .add_op(&MOpcode::OpWiden(rhs_size), address, vt);
                     self.phiplacer.op_use(&casted_lhs, 0, lhs.as_ref().expect("lhs cannot be `None`"));
                     (casted_lhs, rhs.expect(""))
                 }
-                Ordering::Equal => {
+                cmp::Ordering::Equal => {
                     (lhs.expect(""), rhs.expect(""))
                 }
             };
@@ -507,15 +505,11 @@ mod test {
     use std::fs::File;
     use std::io::prelude::*;
     use rustc_serialize::json;
-    use r2pipe::structs::{LAliasInfo, LFunctionInfo, LOpInfo, LRegInfo};
+    use r2pipe::structs::{LFunctionInfo, LRegInfo};
     use middle::ssa::ssastorage::SSAStorage;
-    use middle::ssa::ssa_traits::SSAWalk;
     use middle::ir_writer::IRWriter;
-    use middle::dot;
-    use middle::dce;
-    use utils;
+    use middle::{dot, dce};
     use analysis::sccp::sccp;
-    use std::io;
 
 
     const REGISTER_PROFILE: &'static str = "test_files/x86_register_profile.json";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,13 +43,16 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 extern crate regex;
 extern crate petgraph;
 extern crate rustc_serialize;
 extern crate num;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
-#[macro_use] extern crate r2pipe;
+extern crate r2pipe;
 
 extern crate esil;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
-#![allow(dead_code)]
-#![allow(unused_variables)]
+// #![allow(dead_code)]
+// #![allow(unused_variables)]
 
 extern crate regex;
 extern crate petgraph;

--- a/src/middle/dce.rs
+++ b/src/middle/dce.rs
@@ -8,7 +8,7 @@
 //! Dead code elimination
 
 use std::collections::VecDeque;
-use middle::ssa::ssa_traits::{SSA, SSAExtra, SSAMod};
+use middle::ssa::ssa_traits::{SSAExtra, SSAMod};
 use middle::ssa::ssa_traits::NodeType;
 
 /// Removes SSA nodes that are not used by any other node.

--- a/src/middle/dot.rs
+++ b/src/middle/dot.rs
@@ -12,7 +12,6 @@ use std::hash::Hash;
 use std::cmp::Eq;
 use std::fmt::Debug;
 
-use petgraph::visit::{IntoEdgeReferences, EdgeRef};
 use petgraph::graph::NodeIndex;
 
 

--- a/src/middle/dot.rs
+++ b/src/middle/dot.rs
@@ -44,7 +44,7 @@ impl DotAttrBlock {
     fn bake(&mut self) -> &String {
         let mut r = String::new();
         let attr = if let DotAttrBlock::Hybrid(ref s, ref attr) = *self {
-            r.push_str(&s);
+            r.push_str(s);
             attr.clone()
         } else {
             Vec::new()

--- a/src/middle/ir_writer.rs
+++ b/src/middle/ir_writer.rs
@@ -254,7 +254,7 @@ impl IRWriter {
                                  if !acc.is_empty() {
                                      format!("{}, {}", acc, x)
                                  } else {
-                                     format!("{}", x)
+                                     x
                                  }
                              }))
             }
@@ -286,13 +286,13 @@ impl IRWriter {
                     if let MOpcode::OpConst(_) = opcode {
                         String::new()
                     } else {
-                        let operands = self.fmt_operands(ssa.get_operands(&node).as_slice(), &ssa);
+                        let operands = self.fmt_operands(ssa.get_operands(&node).as_slice(), ssa);
                         indent!(self.indent,
                                 self.fmt_expression(node, opcode, vt, operands, &ssa))
                     }
                 }
                 NodeData::Phi(_, _) => {
-                    let operands = self.fmt_operands(ssa.get_operands(&node).as_slice(), &ssa);
+                    let operands = self.fmt_operands(ssa.get_operands(&node).as_slice(), ssa);
                     let next = self.ctr + 1;
                     let result_idx = self.seen.entry(node).or_insert(next);
                     if *result_idx == next {
@@ -321,7 +321,7 @@ impl IRWriter {
                         if outgoing.len() > 1 {
                             let condition = self.fmt_operands(&[ssa.selector_of(prev_block)
                                                                    .unwrap()],
-                                                              &ssa);
+                                                              ssa);
                             jmp_statement = format!("{} IF {}", jmp_statement, condition[0]);
                         }
 
@@ -377,7 +377,7 @@ impl IRWriter {
                 _ => {
                     format!("{} = {}",
                             ssa.regnames.get(i).unwrap_or_else(|| {
-                                assert!(i == ssa.regnames.len());
+                                assert_eq!(i, ssa.regnames.len());
                                 &mem_comment
                             }),
                             self.fmt_operands(&[*reg], &ssa)[0])

--- a/src/middle/phiplacement.rs
+++ b/src/middle/phiplacement.rs
@@ -11,10 +11,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::cmp::Ordering;
 
-use middle::ssa::ssa_traits::{SSA, SSAMod, ValueType};
+use middle::ssa::ssa_traits::{SSAMod, ValueType};
 use middle::ir::MAddress;
 
-use super::ssa::cfg_traits::{CFG, CFGMod};
 use middle::ssa::ssa_traits::NodeType;
 use middle::regfile::SubRegisterFile;
 use middle::ir::MOpcode;

--- a/src/middle/phiplacement.rs
+++ b/src/middle/phiplacement.rs
@@ -184,10 +184,11 @@ impl<'a, T: SSAMod<BBInfo=MAddress> + 'a> PhiPlacer<'a, T> {
             }
         });
 
-        let mut upper_block = self.ssa.invalid_action();
-        if seen {
-            upper_block = self.block_of(at).unwrap();
-        }
+        let upper_block = if seen {
+            self.block_of(at).unwrap()
+        } else {
+            self.ssa.invalid_action()
+        };
 
         // Create a new block and add the required type of edge.
         let lower_block = self.new_block(at);
@@ -220,7 +221,7 @@ impl<'a, T: SSAMod<BBInfo=MAddress> + 'a> PhiPlacer<'a, T> {
                             ];
             for (i, edge) in outgoing.iter().enumerate() {
                 if *edge != self.ssa.invalid_edge() {
-                    let target = self.ssa.target_of(&edge);
+                    let target = self.ssa.target_of(edge);
                     if lower_block != target {
                         self.ssa.add_control_edge(lower_block, target, i as u8);
                         self.ssa.remove_control_edge(*edge);
@@ -357,7 +358,7 @@ impl<'a, T: SSAMod<BBInfo=MAddress> + 'a> PhiPlacer<'a, T> {
             if use_ == phi {
                 continue;
             }
-            if let Ok(_) = self.ssa.get_node_data(&use_) {
+            if self.ssa.get_node_data(&use_).is_ok() {
                 self.try_remove_trivial_phi(use_);
             }
         }

--- a/src/middle/ssa/ssadot.rs
+++ b/src/middle/ssa/ssadot.rs
@@ -13,7 +13,7 @@ use petgraph::visit::{IntoEdgeReferences, EdgeRef};
 use middle::ir::MOpcode;
 use middle::dot::{DotAttrBlock, GraphDot};
 use super::ssastorage::{EdgeData, NodeData, SSAStorage};
-use super::ssa_traits::{SSA, SSAExtra, SSAMod, ValueType};
+use super::ssa_traits::{SSA, SSAExtra, ValueType};
 use middle::ssa::cfg_traits::CFG;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -249,8 +249,9 @@ impl SSAStorage {
         let mut adjacent = Vec::new();
         let mut walk = self.g.neighbors_directed(node, direction).detach();
         while let Some((edge, othernode)) = walk.next(&self.g) {
-            match self.g[edge] {
-                EdgeData::Data(i) | EdgeData::Control(i) => adjacent.push((i, othernode)),
+            match (data, self.g[edge]) {
+                (true, EdgeData::Data(i)) |
+                (false, EdgeData::Control(i)) => adjacent.push((i, othernode)),
                 _ => {}
             }
         }

--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -249,14 +249,9 @@ impl SSAStorage {
         let mut adjacent = Vec::new();
         let mut walk = self.g.neighbors_directed(node, direction).detach();
         while let Some((edge, othernode)) = walk.next(&self.g) {
-            if data {
-                if let EdgeData::Data(i) = self.g[edge] {
-                    adjacent.push((i, othernode))
-                }
-            } else {
-                if let EdgeData::Control(i) = self.g[edge] {
-                    adjacent.push((i, othernode));
-                }
+            match self.g[edge] {
+                EdgeData::Data(i) | EdgeData::Control(i) => adjacent.push((i, othernode)),
+                _ => {}
             }
         }
         adjacent.sort_by(|a, b| a.0.cmp(&b.0));
@@ -291,12 +286,12 @@ impl CFG for SSAStorage {
     }
 
     fn start_node(&self) -> NodeIndex {
-        assert!(self.start_node != NodeIndex::end());
+        assert_ne!(self.start_node, NodeIndex::end());
         self.start_node
     }
 
     fn exit_node(&self) -> NodeIndex {
-        assert!(self.exit_node != NodeIndex::end());
+        assert_ne!(self.exit_node, NodeIndex::end());
         self.exit_node
     }
 
@@ -582,7 +577,7 @@ impl SSA for SSAStorage {
     fn get_branches(&self, exi: &NodeIndex) -> (NodeIndex, NodeIndex) {
         let selects_for_e = self.selects_for(exi);
         // Make sure that we have a block for the selector.
-        assert!(selects_for_e != NodeIndex::end());
+        assert_ne!(selects_for_e, NodeIndex::end());
         let selects_for = selects_for_e;
 
         let mut true_branch = NodeIndex::end();
@@ -744,8 +739,7 @@ impl SSAMod for SSAStorage {
         let data = NodeData::Op(MOpcode::OpConst(value),
                                 ValueType::Integer { width: 64 });
 
-        let i = self.insert_node(data);
-        i
+        self.insert_node(data)
     }
 
     fn add_phi(&mut self, vt: ValueType) -> NodeIndex {

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -37,34 +37,34 @@ pub enum Event<'a, T: 'a + Debug> {
 impl<'a, T: Debug> ToString for Event<'a, T> {
     fn to_string(&self) -> String {
         match *self {
-            Event::SSAInsertNode(ref i, ref j) => {
+            Event::SSAInsertNode(i, j) => {
                 format!("{}|{:?}|{:?}", "ssa_insert_node", i, j)
             }
-            Event::SSARemoveNode(ref i) => {
+            Event::SSARemoveNode(i) => {
                 format!("{}|{:?}", "ssa_remove_node", i)
             }
-            Event::SSAReplaceNode(ref i, ref j) => {
+            Event::SSAReplaceNode(i, j) => {
                 format!("{}|{:?}|{:?}", "ssa_replace", i, j)
             }
-            Event::SSAInsertEdge(ref i, ref j) => {
+            Event::SSAInsertEdge(i, j) => {
                 format!("{}|{:?}|{:?}", "ssa_insert_edge", i, j)
             }
-            Event::SSARemoveEdge(ref i, ref j) => {
+            Event::SSARemoveEdge(i, j) => {
                 format!("{}|{:?}|{:?}", "ssa_remove_edge", i, j)
             }
-            Event::SSAUpdateEdge(ref i, ref j) => {
+            Event::SSAUpdateEdge(i, j) => {
                 format!("{}|{:?}|{:?}", "ssa_update_edge", i, j)
             }
-            Event::SSAMarkNode(ref i) => {
+            Event::SSAMarkNode(i) => {
                 format!("{}|{:?}", "ssa_mark_node", i)
             }
-            Event::SSAClearMark(ref i) => {
+            Event::SSAClearMark(i) => {
                 format!("{}|{:?}", "ssa_clear_mark", i)
             }
-            Event::SSAQueryExternal(ref i) => {
+            Event::SSAQueryExternal(i) => {
                 format!("{}|{:?}", "ssa_query_external", i)
             }
-            Event::SSAQueryInternal(ref i) => {
+            Event::SSAQueryInternal(i) => {
                 format!("{}|{:?}", "ssa_query_internal", i)
             }
         }

--- a/tests/bin_ls_test.rs
+++ b/tests/bin_ls_test.rs
@@ -14,8 +14,8 @@ use radeco_lib::frontend::ssaconstructor::SSAConstruct;
 use radeco_lib::middle::ssa::ssastorage::SSAStorage;
 use radeco_lib::middle::ir_writer::IRWriter;
 use radeco_lib::middle::{dce, dot};
-use radeco_lib::analysis::sccp::sccp;
-use radeco_lib::analysis::cse::cse::CSE;
+use radeco_lib::analysis::sccp;
+use radeco_lib::analysis::cse::CSE;
 
 use radeco_lib::analysis::matcher::gmatch;
 use radeco_lib::backend::x86::x86_idioms;

--- a/tests/bin_ls_test.rs
+++ b/tests/bin_ls_test.rs
@@ -7,7 +7,6 @@ extern crate rustc_serialize;
 use std::fs::File;
 use std::io::prelude::*;
 use rustc_serialize::json;
-use std::io;
 
 use r2pipe::structs::{LFunctionInfo, LRegInfo};
 
@@ -56,12 +55,9 @@ fn run_construction() -> SSAStorage {
 }
 
 fn run_sccp(ssa: &mut SSAStorage) -> SSAStorage {
-    let mut ssa = {
-        let mut analyzer = sccp::Analyzer::new(ssa);
-        analyzer.analyze();
-        analyzer.emit_ssa()
-    };
-    ssa
+    let mut analyzer = sccp::Analyzer::new(ssa);
+    analyzer.analyze();
+    analyzer.emit_ssa()
 }
 
 fn run_cse(ssa: &mut SSAStorage) -> SSAStorage {

--- a/tests/complete_test1.rs
+++ b/tests/complete_test1.rs
@@ -60,7 +60,6 @@ extern crate rustc_serialize;
 use std::fs::File;
 use std::io::prelude::*;
 use rustc_serialize::json;
-use std::io;
 
 use r2pipe::structs::{LFunctionInfo, LRegInfo};
 

--- a/tests/complete_test1.rs
+++ b/tests/complete_test1.rs
@@ -67,8 +67,8 @@ use radeco_lib::frontend::ssaconstructor::SSAConstruct;
 use radeco_lib::middle::ssa::ssastorage::SSAStorage;
 use radeco_lib::middle::ir_writer::IRWriter;
 use radeco_lib::middle::{dce, dot};
-use radeco_lib::analysis::sccp::sccp;
-use radeco_lib::analysis::cse::cse::CSE;
+use radeco_lib::analysis::sccp;
+use radeco_lib::analysis::cse::CSE;
 
 use radeco_lib::analysis::matcher::gmatch;
 use radeco_lib::backend::x86::x86_idioms;


### PR DESCRIPTION
Not all warning have been fixed:
- docs warnings (they need some huge argueable refactorings, e.g `SSA` -> `Ssa`)
- `unused result must being used`, due to it requires some logic for handling. So imo it's fine to dirty output for some time
- stuff that I don't know how to fix "elegantly" and don't making things worse
- unused vars/fns that don't require additional logic (just comment out or so) <- too long and useless to fix.
  ~~Also w/o clippy those are omitted by [this](https://github.com/radare/radeco-lib/pull/56/files#diff-b4aea3e418ccdb71239b96952d9cddb6R46) (maybe needs a revert?)~~ reverted