### PR TITLE
Rewrite SSA Verifier and add it into tests.

### DIFF
--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -10,6 +10,7 @@ use std::env;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process;
 use petgraph::graph::{EdgeIndex,  NodeIndex};
 
 use r2pipe::r2::R2;
@@ -117,7 +118,14 @@ fn main() {
         {
             // Verify SSA 
             println!("  [*] Verifying SSA's Validity");
-            verifier::verify(&rfn.ssa).unwrap();
+            match verifier::verify(&rfn.ssa) {
+                Err(e) => {
+                    println!("  [*] Found Error: {}", e);
+                    process::exit(255);
+                }
+                Ok(_) => {  }
+                _ => unreachable!()
+            }
         }
         let mut memory_ssa = {
             // Generate MemorySSA

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -23,6 +23,7 @@ use radeco_lib::frontend::containers::RadecoModule;
 use radeco_lib::middle::dce;
 use radeco_lib::middle::ir_writer::IRWriter;
 use radeco_lib::middle::ssa::memoryssa::MemorySSA;
+use radeco_lib::middle::ssa::verifier;
 
 const USAGE: &'static str = "
 Usage: minidec [-f <names>...] <target>
@@ -90,7 +91,6 @@ fn main() {
 
         let ref mut rfn = rmod.functions.get_mut(&addr).unwrap();
 
-
         println!("[+] Analyzing: {} @ {:#x}", rfn.name, addr);
         {
             println!("  [*] Eliminating Dead Code");
@@ -113,6 +113,14 @@ fn main() {
             println!("  [*] Eliminating Common SubExpressions");
             let mut cse = CSE::new(&mut rfn.ssa);
             cse.run();
+        }
+        {
+            // Verify SSA 
+            println!("  [*] Verifying SSA's Validity");
+            match verifier::verify(&rfn.ssa) {
+                Ok(_) => { println!("  [*] PASS"); }
+                Err(e) => { panic!(e); }
+            }
         }
         let mut memory_ssa = {
             // Generate MemorySSA

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -117,10 +117,7 @@ fn main() {
         {
             // Verify SSA 
             println!("  [*] Verifying SSA's Validity");
-            match verifier::verify(&rfn.ssa) {
-                Ok(_) => { println!("  [*] PASS"); }
-                Err(e) => { panic!(e); }
-            }
+            verifier::verify(&rfn.ssa).unwrap();
         }
         let mut memory_ssa = {
             // Generate MemorySSA

--- a/src/analysis/sccp.rs
+++ b/src/analysis/sccp.rs
@@ -399,7 +399,7 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
     pub fn emit_ssa(&mut self) -> T {
         for (k, v) in &self.expr_val {
             if let LatticeValue::Const(val) = *v {
-                println!("{:?} with {:?} --> Const {:#}", 
+                radeco_trace!("{:?} with {:?} --> Const {:#}", 
                               k, self.g.get_node_data(k), val);
                 // BUG: Width may be changed just using a simple replace.
                 let const_node = self.g.add_const(val);
@@ -411,7 +411,6 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
                     const_node
                 } else {
                     // val should not be larger than the k node could be.  
-                    println!("w is {:#}", w);
                     assert!(w < 64 && val < (1 << (w)));
                     let address = self.g.get_address(k);
                     let opcode = MOpcode::OpNarrow(w as u16);

--- a/src/analysis/sccp.rs
+++ b/src/analysis/sccp.rs
@@ -272,7 +272,9 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
 
         // We should consider width.
         let ndata = self.g.get_node_data(i).unwrap();
-        let ValueType::Integer{ width: w } = ndata.vt;
+        let w = match ndata.vt {
+            ValueType::Integer { width } => width,
+        };
         if w != 64 {
             val = val & ((1 << (w)) - 1);
         }
@@ -387,7 +389,9 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
                 // BUG: Width may be changed just using a simple replace.
                 let const_node = self.g.add_const(val);
                 let ndata = self.g.get_node_data(k).unwrap();
-                let ValueType::Integer{ width: w } = ndata.vt;
+                let w = match ndata.vt {
+                    ValueType::Integer { width } => width,
+                };
                 let new_node = if w == 64 {
                     const_node
                 } else {

--- a/src/analysis/sccp.rs
+++ b/src/analysis/sccp.rs
@@ -230,7 +230,14 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
 
         let mut val: u64 = match opcode {
             MOpcode::OpAdd => {
-                lhs_val + rhs_val
+                // lhs_val + rhs_val
+                // we should avoid integer overflow panic
+                let remained: u64 = u64::MAX - lhs_val;
+                if remained >= rhs_val {
+                    lhs_val + rhs_val
+                } else {
+                    (rhs_val - remained - 1) as u64
+                }
             }
             MOpcode::OpSub => {
                 if lhs_val >= rhs_val {
@@ -242,6 +249,7 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
                 }
             }
             MOpcode::OpMul => {
+                // TODO: how to handle integer overflow.
                 lhs_val * rhs_val
             }
             MOpcode::OpDiv => {

--- a/src/analysis/sccp.rs
+++ b/src/analysis/sccp.rs
@@ -13,6 +13,7 @@
 //!
 
 use std::collections::{HashMap, VecDeque};
+use std::u64;
 use middle::ssa::ssa_traits::{SSA, SSAMod};
 use middle::ssa::ssa_traits::{NodeType, ValueType};
 use middle::ir::{MArity, MOpcode};
@@ -184,7 +185,6 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
                 const_val & mask
             }
             MOpcode::OpNot => {
-                // Attention: !0 = 18446744073709551615, whose width is not 1
                 !const_val as u64
             }
             MOpcode::OpCall => {
@@ -233,10 +233,12 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
                 lhs_val + rhs_val
             }
             MOpcode::OpSub => {
-                if lhs_val > rhs_val {
+                if lhs_val >= rhs_val {
                     lhs_val - rhs_val
                 } else {
-                    rhs_val - lhs_val
+                    // rhs_val - lhs_val
+                    // This will never integer overflow 
+                    (u64::MAX - rhs_val + lhs_val + 1) as u64
                 }
             }
             MOpcode::OpMul => {

--- a/src/analysis/valueset/fixcall.rs
+++ b/src/analysis/valueset/fixcall.rs
@@ -66,22 +66,22 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
         let mut matched_func_vec: Vec<u64> =
             functions.iter().map(|(fn_addr, rfn)| fn_addr.clone()).collect();
         // Do the first analysis.
-        radeco_trace!("Do the first analysis.");
+        radeco_trace!("CallFixer|Do the first analysis.");
         for fn_addr in &matched_func_vec {
             self.analysis(fn_addr);
         }
         // Do basic fix.
-        radeco_trace!("Do the basic fix.");
+        radeco_trace!("CallFixer|Do the basic fix.");
         for fn_addr in &matched_func_vec {
             self.fix(fn_addr);
         }
         // Do the second analysis.
-        radeco_trace!("Do the second analysis.");
+        radeco_trace!("CallFixer|Do the second analysis.");
         for fn_addr in &matched_func_vec {
             self.reanalysis(fn_addr);
         }
         // Redo fix.
-        radeco_trace!("Redo fix.");
+        radeco_trace!("CallFixer|Redo fix.");
         for fn_addr in &matched_func_vec {
             self.fix(fn_addr);
         }
@@ -96,7 +96,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
         {
             let rfn = self.rmod.functions.get_mut(rfn_addr)
                             .expect("RadecoFunction Not Found!");
-            radeco_trace!("RadecoFunction: {:?}", rfn.name);
+            radeco_trace!("CallFixer|RadecoFunction: {:?}", rfn.name);
             let ssa = rfn.ssa_mut();
             let mut sorter = Sorter::new(ssa);
             sorter.run();
@@ -110,12 +110,12 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             // Here, we check the assumption we made in first analysis.
             // If the SP is not balanced, we will throw a WARN or PANIC.
             // TODO: if the SP is not balanced, please UNDO the fix.
-            radeco_trace!("Global stack_offset: {:?}", stack_offset);
+            radeco_trace!("CallFixer|Global stack_offset: {:?}", stack_offset);
             if let &Some(SP_offset) = self.SP_offsets.get(rfn_addr).unwrap() {
                 let mut max_offset: i64 = 0;
                 // The last SP offset should be the biggest
                 for offset in &stack_offset {
-                    radeco_trace!("{:?} with {:?}: {}", offset.0,
+                    radeco_trace!("CallFixer|{:?} with {:?}: {}", offset.0,
                              ssa.get_node_data(offset.0), offset.1);
                     if offset.1 > &max_offset {
                         max_offset = *offset.1;
@@ -135,8 +135,8 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                 self.analysis_exit_load(ssa, stack_offset)
             )
         };  
-        radeco_trace!("Entry_store {:?}", entry_store);
-        radeco_trace!("Exit_load {:?}", exit_load);
+        radeco_trace!("CallFixer|Entry_store {:?}", entry_store);
+        radeco_trace!("CallFixer|Exit_load {:?}", exit_load);
 
         self.mark_preserved(rfn_addr, entry_store, exit_load);
     }
@@ -145,13 +145,13 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
     // After this, we could at least make sure whether BP is balanced,
     // and then we could spread all the stack offset in the whole funciton.
     pub fn analysis(&mut self, rfn_addr: &u64) {
-        radeco_trace!("Analyze {:#}", rfn_addr);
+        radeco_trace!("CallFixer|Analyze {:#}", rfn_addr);
 
         // Sort operands for commutative opcode first.
         {
             let rfn = self.rmod.functions.get_mut(rfn_addr)
                             .expect("RadecoFunction Not Found!");
-            radeco_trace!("RadecoFunction: {:?}", rfn.name);
+            radeco_trace!("CallFixer|RadecoFunction: {:?}", rfn.name);
             let ssa = rfn.ssa_mut();
             let mut sorter = Sorter::new(ssa);
             sorter.run();
@@ -189,12 +189,12 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
         let call_info: Vec<(LValueRef, Vec<String>)> = {
             let rfn = self.rmod.functions.get(rfn_addr)
                             .expect("RadecoFunction Not Found!");
-            radeco_trace!("RadecoFunction: {:?}", rfn.name);
+            radeco_trace!("CallFixer|RadecoFunction: {:?}", rfn.name);
 
             // calcluate call_info into preserved registers and OpCall node
             self.preserves_for_call_context(rfn.call_sites())
         };
-        radeco_trace!("Call site: {:?}", call_info);
+        radeco_trace!("CallFixer|Call site: {:?}", call_info);
 
         // Edit OpCalls' arguments and uses, by preserved registers
         {
@@ -207,10 +207,10 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                 if let Some(ref name) = self.SP_name {
                     regs.push(name.clone());
                 }
-                radeco_trace!("Preeserved registers are {:?}", regs);
+                radeco_trace!("CallFixer|Preeserved registers are {:?}", regs);
                 // Consider every register
-                radeco_trace!("Consider {:?} with {:?}", node, ssa.get_node_data(&node));
-                radeco_trace!("Callee is {:?}", 
+                radeco_trace!("CallFixer|Consider {:?} with {:?}", node, ssa.get_node_data(&node));
+                radeco_trace!("CallFixer|Callee is {:?}", 
                          ssa.get_node_data(&ssa.get_operands(&node)[0]));
                 for reg in regs {
                     // Calculate replacement and replacer together
@@ -229,11 +229,11 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
 
                     // We have to get a complete replacement pair
                     if replace_pair.len() != 2 {
-                        radeco_trace!("{:?} with {:?} Not Found!", node, reg);
-                        radeco_trace!("Foudn replace_pair {:?}", replace_pair);
+                        radeco_trace!("CallFixer|{:?} with {:?} Not Found!", node, reg);
+                        radeco_trace!("CallFixer|Foudn replace_pair {:?}", replace_pair);
                         continue;
                     }
-                    radeco_trace!("{:?} with {:?} Found {:?}", node, reg, replace_pair);
+                    radeco_trace!("CallFixer|{:?} with {:?} Found {:?}", node, reg, replace_pair);
 
                     ssa.replace(replace_pair[1], replace_pair[0]);
                 }
@@ -279,7 +279,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             (preserves, SP_offset)
         };
 
-        radeco_trace!("{:?} with {:?}", preserves, SP_offset);
+        radeco_trace!("CallFixer|{:?} with {:?}", preserves, SP_offset);
 
         // Store data into RadecoFunction
         {
@@ -290,7 +290,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                 if preserves.contains(&bind.name()) {
                     bind.mark_preserved();
                 }
-                radeco_trace!("Bind: {:?}", bind);
+                radeco_trace!("CallFixer|Bind: {:?}", bind);
             }
         }
         
@@ -318,12 +318,12 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             } else {
                 continue;
             }
-            radeco_trace!("Pop {:?} with {:?}", node, ssa.get_node_data(&node));
-            radeco_trace!("Register is {:?}", ssa.register(&node));
+            radeco_trace!("CallFixer|Pop {:?} with {:?}", node, ssa.get_node_data(&node));
+            radeco_trace!("CallFixer|Register is {:?}", ssa.register(&node));
             let args = ssa.args_of(node);
             for arg in args {
-                radeco_trace!("Arg: {:?} with {:?}", arg, ssa.get_node_data(&arg));
-                radeco_trace!("Register is {:?}", ssa.register(&arg));
+                radeco_trace!("CallFixer|Arg: {:?} with {:?}", arg, ssa.get_node_data(&arg));
+                radeco_trace!("CallFixer|Register is {:?}", ssa.register(&arg));
 
                 // We only consider registers.
                 if ssa.register(&arg).is_none() {
@@ -343,12 +343,12 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                     Some(MOpcode::OpLoad) => {
                         let operands = ssa.get_operands(&arg);
                         // Seconde operand will be the target address.
-                        radeco_trace!("OpLoad {:?} with {:?}", arg,
+                        radeco_trace!("CallFixer|OpLoad {:?} with {:?}", arg,
                                     ssa.get_node_data(&arg));
-                        radeco_trace!("Register: {:?}", ssa.register(&arg));
-                        radeco_trace!("Target {:?} with {:?}", operands[1],
+                        radeco_trace!("CallFixer|Register: {:?}", ssa.register(&arg));
+                        radeco_trace!("CallFixer|Target {:?} with {:?}", operands[1],
                                     ssa.get_node_data(&operands[1]));
-                        radeco_trace!("Target's register: {:?}", ssa.register(&operands[1]));
+                        radeco_trace!("CallFixer|Target's register: {:?}", ssa.register(&operands[1]));
                         
                         // Consider the target address
                         if !exit_offset.contains_key(&operands[1]) {
@@ -357,7 +357,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
 
                         let base = exit_offset.get(&operands[1]).unwrap().clone();
                         let name = ssa.register(&arg).unwrap().name;
-                        radeco_trace!("Found {:?} with {:?}", name, base);
+                        radeco_trace!("CallFixer|Found {:?} with {:?}", name, base);
                         // We store the nearest OpLoad
                         if exit_load.contains_key(&name) {
                             continue;
@@ -369,7 +369,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             }
         }
 
-        radeco_trace!("Exit_load: {:?}", exit_load);
+        radeco_trace!("CallFixer|Exit_load: {:?}", exit_load);
         exit_load
     }
 
@@ -387,20 +387,20 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             if ssa.get_comment(node).is_none(){
                 continue;
             }
-            radeco_trace!("Comment Node: {:?}", ssa.get_node_data(node));
+            radeco_trace!("CallFixer|Comment Node: {:?}", ssa.get_node_data(node));
             if ssa.register(node).is_none() {
                 continue;
             }
             let reg_name = ssa.register(node).unwrap().name;
-            radeco_trace!("Register's name: {:?}", reg_name);
+            radeco_trace!("CallFixer|Register's name: {:?}", reg_name);
             
             let users = ssa.get_uses(node);
-            radeco_trace!("Uses: {:?} with {:?}", users, ssa.get_node_data(&users[0]));
+            radeco_trace!("CallFixer|Uses: {:?} with {:?}", users, ssa.get_node_data(&users[0]));
 
             for user in &users {
                 if Some(MOpcode::OpStore) == ssa.get_opcode(user) {
                     let args = ssa.get_operands(user);
-                    radeco_trace!("OpStore's operands {:?}", args);
+                    radeco_trace!("CallFixer|OpStore's operands {:?}", args);
                     // OpStore is not commutative, thus the second operand will be the address
                     if entry_offset.contains_key(&args[1]) {
                         let num = entry_offset.get(&args[1]).unwrap();
@@ -410,7 +410,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             }
         }
 
-        radeco_trace!("Entry_store is {:?}", entry_store);
+        radeco_trace!("CallFixer|Entry_store is {:?}", entry_store);
         entry_store
     } 
 
@@ -427,10 +427,10 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
         let reg_state = ssa.registers_at(&ssa.exit_node());
         let nodes = ssa.args_of(reg_state);
         for node in &nodes {
-            radeco_trace!("{:?} with {:?}", node, ssa.get_node_data(node));
+            radeco_trace!("CallFixer|{:?} with {:?}", node, ssa.get_node_data(node));
             if let Some(reg) = ssa.register(node) {
                 if reg.alias_info == Some(String::from("SP")) {
-                    radeco_trace!("Initial data {:?} is {:?}", node, ssa.get_node_data(node));
+                    radeco_trace!("CallFixer|Initial data {:?} is {:?}", node, ssa.get_node_data(node));
                     stack_offset.insert(*node, 0);
                     worklist.push_back(*node);
                 }
@@ -448,9 +448,9 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             let args = ssa.get_operands(&node);
 
             // For exit node, it's possible that there is not only one node.
-            radeco_trace!("Pop {:?} with {:?}", node, ssa.get_node_data(&node));
-            radeco_trace!("Register: {:?}", ssa.register(&node));
-            radeco_trace!("Args: {:?}", args);
+            radeco_trace!("CallFixer|Pop {:?} with {:?}", node, ssa.get_node_data(&node));
+            radeco_trace!("CallFixer|Register: {:?}", ssa.register(&node));
+            radeco_trace!("CallFixer|Args: {:?}", args);
 
             // We have to consider the OpNarrow/OpWiden which uses node.
             let users = ssa.get_uses(&node);
@@ -507,7 +507,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             }
         }        
     
-        radeco_trace!("Stack_offset: {:?}", stack_offset);
+        radeco_trace!("CallFixer|Stack_offset: {:?}", stack_offset);
         stack_offset
     }
 
@@ -526,7 +526,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                 if ssa.get_comment(node).is_none() {
                     continue;
                 }
-                radeco_trace!("Comment Node {:?}: {:?}", node, ssa.get_node_data(node));
+                radeco_trace!("CallFixer|Comment Node {:?}: {:?}", node, ssa.get_node_data(node));
                 if ssa.register(node).is_none() {
                     continue;
                 }
@@ -535,7 +535,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                     != Some(String::from("SP")) {
                         continue;
                 }
-                radeco_trace!("Initial data is {:?}\n", ssa.get_node_data(node));
+                radeco_trace!("CallFixer|Initial data is {:?}\n", ssa.get_node_data(node));
                 stack_offset.insert(*node, 0);
                 break;
             }
@@ -551,7 +551,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
         } else {
             let blocks = ssa.succs_of(ssa.start_node());
             assert_eq!(blocks.len(), 1);
-            radeco_trace!("Found: {:?}", blocks);
+            radeco_trace!("CallFixer|Found: {:?}", blocks);
             ssa.exprs_in(&blocks[0])
         };
 
@@ -575,8 +575,8 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                 // Consider OpWiden, especially for 32-bits binary.
                 match opc {
                     MOpcode::OpWiden(_) | MOpcode::OpNarrow(_) => {
-                        radeco_trace!("Widen/Narrow Node: {:?}", node);
-                        radeco_trace!("Widen/Narrow argumes: {:?}", 
+                        radeco_trace!("CallFixer|Widen/Narrow Node: {:?}", node);
+                        radeco_trace!("CallFixer|Widen/Narrow argumes: {:?}", 
                                         ssa.get_operands(node));
                         let args = ssa.get_operands(node);
                         if stack_offset.contains_key(&args[0]) {
@@ -603,7 +603,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                     alias_name != String::from("BP") {
                         continue;
                     }
-                radeco_trace!("Found {:?} {:?}, with {:?}", node, 
+                radeco_trace!("CallFixer|Found {:?} {:?}, with {:?}", node, 
                                     ssa.get_node_data(node), 
                                     ssa.register(node));
 
@@ -643,10 +643,10 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                     (ssa.is_phi(&args[opcode_arg as usize]) && is_global) {
                     if let Some(MOpcode::OpConst(num)) = 
                                 ssa.get_opcode(&args[const_arg as usize]) {
-                        radeco_trace!("SP/BP operation found {:?}, with {:?}", node,
+                        radeco_trace!("CallFixer|SP/BP operation found {:?}, with {:?}", node,
                                  ssa.register(node));
-                        radeco_trace!("Node data is {:?}", ssa.get_node_data(&node));
-                        radeco_trace!("Equal to {:?} {:?} +/- {:?} {:?}",
+                        radeco_trace!("CallFixer|Node data is {:?}", ssa.get_node_data(&node));
+                        radeco_trace!("CallFixer|Equal to {:?} {:?} +/- {:?} {:?}",
                                  args[0],
                                  ssa.get_node_data(&args[0]),
                                  args[1],
@@ -661,7 +661,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                         // A trick to distinguish OpAdd/OpSub.
                         stack_offset.insert(*node, 
                                     base + (opcode_arg - const_arg) * (num as i64));
-                        radeco_trace!("New offset for it: {:?}", 
+                        radeco_trace!("CallFixer|New offset for it: {:?}", 
                                     base + (opcode_arg - const_arg) *
                                     (num as i64));
                         continue;
@@ -684,13 +684,13 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                 }
                 if nums.len() == 1 {
                     stack_offset.insert(*node, nums[0]);
-                    radeco_trace!("New offset for it: {:?}", nums[0]); 
+                    radeco_trace!("CallFixer|New offset for it: {:?}", nums[0]); 
                 } else {
-                    radeco_trace!("Phi's information: {:?}", ssa.register(&node));
+                    radeco_trace!("CallFixer|Phi's information: {:?}", ssa.register(&node));
                 }
             }
         }
-        radeco_trace!("Stack_offset: {:?}", stack_offset);
+        radeco_trace!("CallFixer|Stack_offset: {:?}", stack_offset);
         stack_offset
     }
 

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -223,6 +223,7 @@ impl<'a, T> SSAConstruct<'a, T>
                 } else {
                     // This means that we're performing a memory write. So we need to emit an
                     // OpStore operation.
+                    radeco_warn!("Memory Write happends!");
                     let op_node = self.phiplacer.add_op(&MOpcode::OpStore,
                                                         address,
                                                         ValueType::Integer { width: 0 });
@@ -496,7 +497,10 @@ impl<'a, T> SSAConstruct<'a, T>
                 current_address.offset += 1;
             }
         }
-        self.phiplacer.add_edge(current_address, MAddress::new(u64::MAX, 0), UNCOND_EDGE);
+        // BUG: The last block may not have the biggest address, which means current_address 
+        // may be not in the last basic block
+        // self.phiplacer.add_edge(current_address, MAddress::new(u64::MAX, 0), UNCOND_EDGE);
+        self.phiplacer.gather_exits();
         self.phiplacer.finish();
     }
 } // end impl SSAConstruct

--- a/src/middle/ir.rs
+++ b/src/middle/ir.rs
@@ -170,7 +170,7 @@ impl MOpcode {
             MOpcode::OpLsr => ("OpLsr".to_owned(), MArity::Binary),
             MOpcode::OpIf => ("OpIf".to_owned(), MArity::Unary),
             MOpcode::OpLoad => ("OpLoad".to_owned(), MArity::Binary),
-            MOpcode::OpStore => ("OpStore".to_owned(), MArity::Ternary),
+            MOpcode::OpStore => ("OpStore".to_owned(), MArity::Binary),
             MOpcode::OpNarrow(_) => ("OpNarrow".to_owned(), MArity::Unary),
             MOpcode::OpWiden(_) => ("OpWiden".to_owned(), MArity::Unary),
             MOpcode::OpJmp => ("OpJmp".to_owned(), MArity::Unary),

--- a/src/middle/ir.rs
+++ b/src/middle/ir.rs
@@ -170,7 +170,7 @@ impl MOpcode {
             MOpcode::OpLsr => ("OpLsr".to_owned(), MArity::Binary),
             MOpcode::OpIf => ("OpIf".to_owned(), MArity::Unary),
             MOpcode::OpLoad => ("OpLoad".to_owned(), MArity::Binary),
-            MOpcode::OpStore => ("OpStore".to_owned(), MArity::Binary),
+            MOpcode::OpStore => ("OpStore".to_owned(), MArity::Ternary),
             MOpcode::OpNarrow(_) => ("OpNarrow".to_owned(), MArity::Unary),
             MOpcode::OpWiden(_) => ("OpWiden".to_owned(), MArity::Unary),
             MOpcode::OpJmp => ("OpJmp".to_owned(), MArity::Unary),

--- a/src/middle/mod.rs
+++ b/src/middle/mod.rs
@@ -21,4 +21,5 @@ pub mod ssa {
     pub mod error;
     pub mod ssadot;
     pub mod memoryssa;
+    pub mod verifier;
 }

--- a/src/middle/phiplacement.rs
+++ b/src/middle/phiplacement.rs
@@ -133,12 +133,9 @@ impl<'a, T: SSAMod<BBInfo=MAddress> + SSAExtra +  'a> PhiPlacer<'a, T> {
             }
         } else {
             // Incomplete CFG
-            // Actually, the incomplete_phis should not have the variable key.
             let val_ = self.add_phi(address, valtype);
             let block_addr = self.addr_of(&block);
             if let Some(hash) = self.incomplete_phis.get_mut(&block_addr) {
-                assert!(hash.get(&variable).is_none(), "Double phi nodes for a same variable in\
-                 same block!");
                 match hash.get(&variable).cloned() {
                     Some(v) => v,
                     None => {

--- a/src/middle/ssa/error.rs
+++ b/src/middle/ssa/error.rs
@@ -23,6 +23,8 @@ pub enum SSAErr<T: SSA + Debug> {
     UnreachableBlock(T::ActionRef),
     InvalidExpr(T::ValueRef),
     IncompatibleWidth(T::ValueRef, u16, u16),
+    BackUse(T::ValueRef, T::ValueRef),
+    UnreachablePhiSCC(Vec<T::ValueRef>),
 }
 
 impl fmt::Display for SSAErr<SSAStorage> {
@@ -63,6 +65,12 @@ impl fmt::Display for SSAErr<SSAStorage> {
             }
             SSAErr::IncompatibleWidth(ni, e, f) => {
                 format!("{:?} expected with to be {}, found width: {}", ni, e, f)
+            }
+            SSAErr::BackUse(ref i, ref j) => {
+                format!("Found back use from {:?} to {:?}", i, j)
+            }
+            SSAErr::UnreachablePhiSCC(ref nodes) => {
+                format!("Found Use-Def chains become a loop: {:?}", nodes)
             }
         };
         write!(f, "{}.", err)

--- a/src/middle/ssa/memoryssa.rs
+++ b/src/middle/ssa/memoryssa.rs
@@ -135,13 +135,13 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     /// Run to generate MemorySSA.
     pub fn run(&mut self) {
         self.gather_may_aliases();
-        radeco_trace!("May_alias Set: {:?}", self.may_aliases);
+        radeco_trace!("MemorrySSA|May_alias Set: {:?}", self.may_aliases);
         // Gather may_alias sets.
-        radeco_trace!("Gather may_alias done!");
+        radeco_trace!("MemorrySSA|Gather may_alias done!");
 
         self.generate();
         // Calculate MemorySSA.
-        radeco_trace!("generate done!");
+        radeco_trace!("MemorrySSA|generate done!");
     }
 
     // Gather variables in following rules:
@@ -153,7 +153,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
                         datafers: &Option<Vec<u64>>,
                         locals: &Option<Vec<LVarInfo>>,
                         callrefs: &Option<Vec<NodeIndex>>) {
-        radeco_trace!("Get datafers: {:?}", datafers);
+        radeco_trace!("MemorrySSA|Get datafers: {:?}", datafers);
         // datafers is coming from RadecoFunctoin::datafers
         if !datafers.is_none() {
             let mut gvars: Vec<VariableType> 
@@ -165,7 +165,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
             self.variables.append(&mut gvars);
         }
 
-        radeco_trace!("Get locals: {:?}", locals);
+        radeco_trace!("MemorrySSA|Get locals: {:?}", locals);
         // locals is coming from RadecoFunctoin::locals
         if !locals.is_none() {
             let mut lvars: Vec<VariableType>
@@ -177,7 +177,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
             self.variables.append(&mut lvars);
         }
 
-        radeco_trace!("Get callrefs: {:?}", callrefs);
+        radeco_trace!("MemorrySSA|Get callrefs: {:?}", callrefs);
         // callrefs is coming from RadecoFunctoin::call_ctx::ssa_ref
         if !callrefs.is_none() {
             let mut evars: Vec<VariableType>
@@ -189,7 +189,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
             self.variables.append(&mut evars);
         }
 
-        radeco_trace!("Gather variables: {:?}", self.variables);
+        radeco_trace!("MemorrySSA|Gather variables: {:?}", self.variables);
 
         // Resize associated data structures
         for i in 0..self.variables.len() {
@@ -200,11 +200,11 @@ impl<'a, I, T> MemorySSA<'a, I, T>
 
     // Check addr could be regared as a global variable's address or not
     fn check_global(&self, addr: u64) -> bool {
-        radeco_trace!("New const added into test: {:?}", addr);
+        radeco_trace!("MemorrySSA|New const added into test: {:?}", addr);
         for var in &self.variables {
             if let VariableType::Global(target) = *var {
                 if addr == target {
-                    radeco_trace!("New global address found: {:?}", addr);
+                    radeco_trace!("MemorrySSA|New global address found: {:?}", addr);
                     return true;
                 }
             }
@@ -214,7 +214,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
 
     // Check reg is a BP/SP register or not
     fn check_local(&self, mut comment: String) -> bool {
-        radeco_trace!("New comment added into test: {:?}", &comment);
+        radeco_trace!("MemorrySSA|New comment added into test: {:?}", &comment);
         for var in &self.variables {
             if let VariableType::Local(lvarinfo) = var.clone() {
                 let reg = lvarinfo.reference.unwrap().base.unwrap().clone();
@@ -226,7 +226,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
                 // Attition: Comment may be in format as: reg@address.offset
 
                 if comment == reg {
-                    radeco_trace!("New BP/SP register found: {:?}", comment);
+                    radeco_trace!("MemorrySSA|New BP/SP register found: {:?}", comment);
                     return true;
                 }
             } 
@@ -264,8 +264,8 @@ impl<'a, I, T> MemorySSA<'a, I, T>
                 }
             }
         }
-        radeco_trace!("Find local variable address: {:?}", self.local_nodes);
-        radeco_trace!("Find global variable address: {:?}", self.global_nodes);
+        radeco_trace!("MemorrySSA|Find local variable address: {:?}", self.local_nodes);
+        radeco_trace!("MemorrySSA|Find global variable address: {:?}", self.global_nodes);
     }
     
     // If idx's operands include local addresses or global addresses, it could
@@ -286,13 +286,13 @@ impl<'a, I, T> MemorySSA<'a, I, T>
 
         match (involve_local, involve_global) {
             (true, false) => { 
-                radeco_trace!("Find new local variable address node: {:?}", idx);
+                radeco_trace!("MemorrySSA|Find new local variable address node: {:?}", idx);
                 self.local_nodes.insert(*idx); 
-                radeco_trace!("Local variable address: {:?}", self.local_nodes);
+                radeco_trace!("MemorrySSA|Local variable address: {:?}", self.local_nodes);
             }
             (false, true) => { 
-                radeco_trace!("Find new global variable address node: {:?}", idx);
-                radeco_trace!("Global variable address: {:?}", self.global_nodes);
+                radeco_trace!("MemorrySSA|Find new global variable address node: {:?}", idx);
+                radeco_trace!("MemorrySSA|Global variable address: {:?}", self.global_nodes);
                 self.global_nodes.insert(*idx); 
             }
             _ => {}
@@ -340,7 +340,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
             } 
         }
 
-        radeco_trace!("New may_alias set {:?} for {:?}", may_alias, idx);
+        radeco_trace!("MemorrySSA|New may_alias set {:?} for {:?}", may_alias, idx);
         self.may_aliases.entry(*idx).or_insert(may_alias);
     }
 
@@ -463,7 +463,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     }
 
     fn replace(&mut self, origin: &NodeIndex, replacement: &NodeIndex) {
-        radeco_trace!("Replace {:?} with {:?}", origin, replacement);
+        radeco_trace!("MemorrySSA|Replace {:?} with {:?}", origin, replacement);
         let users = self.get_uses(origin);
         let operands = self.get_operands(origin);
 
@@ -496,7 +496,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
 
     // Recode the current define of variable var. 
     fn write_variable(&mut self, var: VarId, block: &T::ActionRef, mem_node: &NodeIndex) {
-        radeco_trace!("Write variable ({:?}) in block ({:?}) at mem node ({:?})", 
+        radeco_trace!("MemorrySSA|Write variable ({:?}) in block ({:?}) at mem node ({:?})", 
                     var, 
                     block, 
                     mem_node);
@@ -506,7 +506,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     // Get the reachable define for var, if it doesn't exist in this block, call
     // read_variable_recursive to visit block's predecessors.
     fn read_variable(&mut self, var: VarId, block: &T::ActionRef) -> NodeIndex {
-        radeco_trace!("Read variable ({:?}) in block ({:?})", var, block);
+        radeco_trace!("MemorrySSA|Read variable ({:?}) in block ({:?})", var, block);
         if let Some(node) = self.current_def[var].get(block) {
             return node.clone()
         }
@@ -516,8 +516,8 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     // Add phi nodes in the basic block, and visit its predecessors.
     // This function will only be called when the current block doesn't have var's define.
     fn read_variable_recursive(&mut self, var: VarId, block: &T::ActionRef) -> NodeIndex {
-        radeco_trace!("Call read_variable_recursive: {:?} {:?}", var, block);
-        radeco_trace!("Pred Block information {:?}", self.ssa.preds_of(block.clone()));
+        radeco_trace!("MemorrySSA|Call read_variable_recursive: {:?} {:?}", var, block);
+        radeco_trace!("MemorrySSA|Pred Block information {:?}", self.ssa.preds_of(block.clone()));
         let mut val: NodeIndex;
 
         if !self.sealed_blocks.contains(block) {
@@ -572,7 +572,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
             // This phi node only uses itself.
         }
 
-        radeco_trace!("Remove phi node: {:?}", phi);
+        radeco_trace!("MemorrySSA|Remove phi node: {:?}", phi);
         let mut users: Vec<NodeIndex> = Vec::new();
         for user in self.get_uses(phi) {
             if !users.contains(&user) {
@@ -628,7 +628,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
 
         for expr in self.ssa.inorder_walk() {
             if let Ok(ndata) = self.ssa.get_node_data(&expr) {
-                radeco_trace!("Deal with node: {:?}", expr);
+                radeco_trace!("MemorrySSA|Deal with node: {:?}", expr);
 
                 match ndata.nt {
                     NodeType::Op(MOpcode::OpLoad) => {
@@ -670,6 +670,6 @@ impl<'a, I, T> MemorySSA<'a, I, T>
             self.seal_block(&block);
         }
 
-        radeco_trace!("Memory SSA Graph: {:?}", self.g);
+        radeco_trace!("MemorrySSA|Memory SSA Graph: {:?}", self.g);
     }
 }

--- a/src/middle/ssa/verifier.rs
+++ b/src/middle/ssa/verifier.rs
@@ -75,8 +75,8 @@ impl Verify for SSAStorage {
 
         let edges = self.edges_of(block);
 
-        println!("Block {:?}", block);
-        println!("Edges {:?}", edges);
+        radeco_trace!("ssa verify|Block {:?}", block);
+        radeco_trace!("ssa verify|Edges {:?}", edges);
 
         // Every BB can have a maximum of 2 Outgoing CFG Edges.
         // TODO: Relax this assumption when we have support for switch.
@@ -153,10 +153,10 @@ impl Verify for SSAStorage {
     }
 
     fn verify_expr(&self, exi: &NodeIndex) -> VResult<Self> {
-        println!("Node {:?} with {:?}", exi, self.get_node_data(exi));
-        println!("Args: {:?}", self.get_operands(exi));
+        radeco_trace!("ssa verify|Node {:?} with {:?}", exi, self.get_node_data(exi));
+        radeco_trace!("ssa verify|Args: {:?}", self.get_operands(exi));
         for arg in &self.get_operands(exi) {
-            println!("\targ: {:?} with {:?}", arg, self.get_node_data(arg));
+            radeco_trace!("ssa verify|\targ: {:?} with {:?}", arg, self.get_node_data(arg));
         }
         if let Ok(ndata) = self.get_node_data(exi) { 
             match (ndata.nt, ndata.vt) {
@@ -241,9 +241,6 @@ pub fn verify<T>(ssa: &T) -> VResult<T>
     where T: Verify + Debug
 {
     let blocks = ssa.blocks();
-    for block in &blocks {
-        println!("Block {:?} is in {:#}", block, ssa.address(block).unwrap());
-    }
     for block in blocks.iter() {
         // assert the qualities of the block first.
         try!(ssa.verify_block(block));

--- a/src/middle/ssa/verifier.rs
+++ b/src/middle/ssa/verifier.rs
@@ -16,6 +16,7 @@ use super::ssa_traits::{SSA, SSAMod, ValueType};
 use super::ssastorage::EdgeData;
 use super::ssastorage::NodeData;
 use super::ssa_traits::NodeData as TNodeData;
+use super::ssa_traits::NodeType as TNodeType;
 use super::error::SSAErr;
 
 use super::ssastorage::SSAStorage;
@@ -74,6 +75,9 @@ impl Verify for SSAStorage {
 
         let edges = self.edges_of(block);
 
+        println!("Block {:?}", block);
+        println!("Edges {:?}", edges);
+
         // Every BB can have a maximum of 2 Outgoing CFG Edges.
         // TODO: Relax this assumption when we have support for switch.
         check!(edges.len() < 3,
@@ -82,46 +86,41 @@ impl Verify for SSAStorage {
         let mut edgecases = [false; 256];
 
         for edge in edges.iter() {
-            match self.g[*edge] {
-                EdgeData::Control(i) => {
-                    let target = self.target_of(edge);
-                    check!(self.is_action(target),
-                           SSAErr::InvalidType("Block".to_owned()));
-                    check!(!edgecases[i as usize],
-                           SSAErr::InvalidControl(*block, *edge));
-                    edgecases[i as usize] = true;
-                }
-                _ => (),
-            }
+            let target = self.target_of(&edge.0);
+            check!(self.is_action(target),
+                   SSAErr::InvalidType("Block".to_owned()));
+            check!(!edgecases[edge.1 as usize],
+                   SSAErr::InvalidControl(*block, edge.0));
+            edgecases[edge.1 as usize] = true;
         }
 
         for edge in edges.iter() {
-            match self.g[*edge] {
-                EdgeData::Control(i) if i < 2 => {
+            match edge.1 {
+                0 | 1 => {
                     // Things to lookout for:
                     //  * There must be a minimum of two edges.
                     //  * There _must_ be a selector.
                     //  * The jump targets must not be the same block.
                     check!(edges.len() == 2,
                            SSAErr::WrongNumEdges(*block, 2, edges.len()));
-                    let other_edge = match i {
+                    let other_edge = match edge.1 {
                         0 => self.true_edge_of(block),
                         1 => self.false_edge_of(block),
                         _ => unreachable!(),
                     };
-                    let target_1 = self.target_of(edge);
+                    let target_1 = self.target_of(&edge.0);
                     let target_2 = self.target_of(&other_edge);
-                    check!(target_1 != target_2, SSAErr::InvalidControl(*block, *edge));
+                    check!(target_1 != target_2, SSAErr::InvalidControl(*block, edge.0));
                     // No need to test the next edge.
                     break;
                 }
-                EdgeData::Control(2) => {
+                2 => {
                     // Things to lookout for:
                     //  * There can be only one Unconditional Edge.
                     //  * There can be no selector.
                     //  * Make sure we have not introduced an unconditional jump
                     //    which self-loops.
-                    let _ = self.target_of(edge);
+                    let _ = self.target_of(&edge.0);
                     check!(edges.len() == 1,
                            SSAErr::WrongNumEdges(*block, 1, edges.len()));
 
@@ -149,68 +148,92 @@ impl Verify for SSAStorage {
         // TODO: Re-enable this after DCE. Make this Non-Fatal.
         // let incoming = self.incoming_edges(block);
         // check!((incoming.len() > 0) || *block == self.start_node(),
-        // SSAErr::UnreachableBlock(*block));
+        //     SSAErr::UnreachableBlock(*block));
         Ok(())
     }
 
     fn verify_expr(&self, exi: &NodeIndex) -> VResult<Self> {
-        let i = &self.internal(exi);
-        let node_data = &self.g[*i];
-        match *node_data {
-            NodeData::Op(opcode, ValueType::Integer { width: w }) => {
-                let extract = |x: TNodeData| -> u16 {
-                    match x.vt {
-                        ValueType::Integer { width: w } => w,
-                    }
-                };
+        println!("Node {:?} with {:?}", exi, self.get_node_data(exi));
+        println!("Args: {:?}", self.get_operands(exi));
+        for arg in &self.get_operands(exi) {
+            println!("\targ: {:?} with {:?}", arg, self.get_node_data(arg));
+        }
+        if let Ok(ndata) = self.get_node_data(exi) { 
+            match (ndata.nt, ndata.vt) {
+                (TNodeType::Op(opcode), ValueType::Integer { width: w }) => { 
+                    let extract_width = |x: TNodeData| -> u16 {
+                        match x.vt {
+                            ValueType::Integer { width: w } => w,
+                        }
+                    };
 
-                let operands = self.get_operands(exi);
-                let op_len = operands.len();
-                let n = match opcode.arity() {
-                    MArity::Zero => 0,
-                    MArity::Unary => 1,
-                    MArity::Binary => 2,
-                    _ => unreachable!(),
-                };
+                    let opfilter = |&x: &NodeIndex| -> bool {
+                        if let Some(op) = self.get_opcode(&x) {
+                            match op {
+                                MOpcode::OpLoad | MOpcode::OpStore => false,
+                                _ => true,
+                            }
+                        } else {
+                            true
+                        }
+                    };
 
-                {
-                    check!(op_len == n, SSAErr::WrongNumOperands(*i, n, op_len));
-                }
+                    let mut operands = self.get_operands(exi);
+                    let op_len = operands.len();
+                    let n = match opcode.arity() {
+                        MArity::Zero => 0,
+                        MArity::Unary => 1,
+                        MArity::Binary => 2,
+                        _ => unreachable!(),
+                    };
 
-                if n == 0 {
-                    return Ok(());
-                }
-                match opcode {
-                    MOpcode::OpNarrow(w0) => {
-                        let opw = self.get_node_data(&operands[0]).map(&extract).unwrap();
-                        check!(opw > w0, SSAErr::IncompatibleWidth(*i, opw, w0));
-                        check!(w == w0, SSAErr::IncompatibleWidth(*i, w, w0));
+                    // TODO: OpStore is unclear that it could be binary or ternary.
+                    if opcode != MOpcode::OpStore &&
+                        opcode != MOpcode::OpCall {
+                        check!(op_len == n, SSAErr::WrongNumOperands(*exi, n, op_len));
                     }
-                    MOpcode::OpWiden(w0) => {
-                        let opw = self.get_node_data(&operands[0]).map(&extract).unwrap();
-                        check!(opw < w0, SSAErr::IncompatibleWidth(*i, opw, w0));
-                        check!(w == w0, SSAErr::IncompatibleWidth(*i, w, w0));
+
+                    // TODO: We do not consider OpStore and OpLoad's width.
+                    operands.retain(&opfilter);
+
+                    if n == 0 || operands.len() == 0 {
+                        return Ok(());
                     }
-                    MOpcode::OpCmp |
-                    MOpcode::OpGt |
-                    MOpcode::OpLt => {
-                        check!(w == 1, SSAErr::IncompatibleWidth(*i, 1, w));
-                    }
-                    MOpcode::OpCall | MOpcode::OpStore => {}
-                    _ => {
-                        // All operands to an expr must have the same width.
-                        let w0 = self.get_node_data(&operands[0]).map(&extract).unwrap();
-                        check!(w0 == w, SSAErr::IncompatibleWidth(*i, w, w0));
-                        for op in operands.iter() {
-                            let w1 = self.get_node_data(op).map(&extract).unwrap();
-                            check!(w == w1, SSAErr::IncompatibleWidth(*i, w, w1));
+                    match opcode {
+                        MOpcode::OpNarrow(w0) => {
+                            let opw = self.get_node_data(&operands[0]).map(&extract_width).unwrap();
+                            check!(opw > w0, SSAErr::IncompatibleWidth(*exi, opw, w0));
+                            check!(w == w0, SSAErr::IncompatibleWidth(*exi, w, w0));
+                        }
+                        MOpcode::OpWiden(w0) => {
+                            let opw = self.get_node_data(&operands[0]).map(&extract_width).unwrap();
+                            check!(opw < w0, SSAErr::IncompatibleWidth(*exi, opw, w0));
+                            check!(w == w0, SSAErr::IncompatibleWidth(*exi, w, w0));
+                        }
+                        MOpcode::OpCmp |
+                        MOpcode::OpGt |
+                        MOpcode::OpLt => {
+                            check!(w == 1, SSAErr::IncompatibleWidth(*exi, 1, w));
+                        }
+                        // TODO: Width of OpStore and OpLoad now is not certain.
+                        MOpcode::OpCall | MOpcode::OpStore | MOpcode::OpLoad => {}
+                        _ => {
+                            // All operands to an expr must have the same width.
+                            let w0 = self.get_node_data(&operands[0]).map(&extract_width).unwrap();
+                            check!(w0 == w, SSAErr::IncompatibleWidth(*exi, w, w0));
+                            for op in operands.iter() {
+                                let w1 = self.get_node_data(op).map(&extract_width).unwrap();
+                                check!(w == w1, SSAErr::IncompatibleWidth(*exi, w, w1));
+                            }
                         }
                     }
                 }
+                _ => check!(false, SSAErr::InvalidExpr(*exi)),
             }
-            _ => check!(false, SSAErr::InvalidExpr(*i)),
-        }
-        Ok(())
+            Ok(())
+        } else {
+            Err(SSAErr::InvalidExpr(*exi))
+        } 
     }
 }
 
@@ -218,6 +241,9 @@ pub fn verify<T>(ssa: &T) -> VResult<T>
     where T: Verify + Debug
 {
     let blocks = ssa.blocks();
+    for block in &blocks {
+        println!("Block {:?} is in {:#}", block, ssa.address(block).unwrap());
+    }
     for block in blocks.iter() {
         // assert the qualities of the block first.
         try!(ssa.verify_block(block));

--- a/tests/bin_ls_test.rs
+++ b/tests/bin_ls_test.rs
@@ -128,7 +128,6 @@ fn bin_ls_grep_replace() {
         grep_and_replace!(&mut ssa_, "(OpStore mem, (OpSub rsp, #x8), rbp)" => "mem'");
         run_sccp(&mut ssa_)
     };
-    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }
@@ -142,7 +141,6 @@ fn bin_ls_x86_idioms() {
     {
         dce::collect(&mut ssa);
     }
-    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }

--- a/tests/bin_ls_test.rs
+++ b/tests/bin_ls_test.rs
@@ -12,6 +12,7 @@ use r2api::structs::{LFunctionInfo, LRegInfo};
 
 use radeco_lib::frontend::ssaconstructor::SSAConstruct;
 use radeco_lib::middle::ssa::ssastorage::SSAStorage;
+use radeco_lib::middle::ssa::verifier;
 use radeco_lib::middle::ir_writer::IRWriter;
 use radeco_lib::middle::{dce, dot};
 use radeco_lib::analysis::sccp;
@@ -71,6 +72,7 @@ fn run_cse(ssa: &mut SSAStorage) -> SSAStorage {
 #[test]
 fn bin_ls_construction() {
     let ssa = run_construction();
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }
@@ -81,6 +83,7 @@ fn bin_ls_sccp() {
         let mut ssa_ = run_construction();
         run_sccp(&mut ssa_)
     };
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }
@@ -91,6 +94,7 @@ fn bin_ls_cse() {
         let mut ssa_ = run_construction();
         run_cse(&mut ssa_)
     };
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }
@@ -104,6 +108,7 @@ fn bin_ls_cse_sccp() {
         }
         run_sccp(&mut ssa_)
     };
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }
@@ -123,6 +128,7 @@ fn bin_ls_grep_replace() {
         grep_and_replace!(&mut ssa_, "(OpStore mem, (OpSub rsp, #x8), rbp)" => "mem'");
         run_sccp(&mut ssa_)
     };
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }
@@ -136,6 +142,7 @@ fn bin_ls_x86_idioms() {
     {
         dce::collect(&mut ssa);
     }
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }

--- a/tests/complete_test1.rs
+++ b/tests/complete_test1.rs
@@ -65,6 +65,7 @@ use r2api::structs::{LFunctionInfo, LRegInfo};
 
 use radeco_lib::frontend::ssaconstructor::SSAConstruct;
 use radeco_lib::middle::ssa::ssastorage::SSAStorage;
+use radeco_lib::middle::ssa::verifier;
 use radeco_lib::middle::ir_writer::IRWriter;
 use radeco_lib::middle::{dce, dot};
 use radeco_lib::analysis::sccp;
@@ -130,6 +131,7 @@ fn run_cse(ssa: &mut SSAStorage) -> SSAStorage {
 #[test]
 fn ct1_construction() {
     let ssa = run_construction();
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }
@@ -140,6 +142,7 @@ fn ct1_sccp() {
         let mut ssa_ = run_construction();
         run_sccp(&mut ssa_)
     };
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }
@@ -150,6 +153,7 @@ fn ct1_cse() {
         let mut ssa_ = run_construction();
         run_cse(&mut ssa_)
     };
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }
@@ -163,6 +167,7 @@ fn ct1_cse_sccp() {
         }
         run_sccp(&mut ssa_)
     };
+    verifier::verify(&ssa).unwrap();
     let mut writer: IRWriter = Default::default();
     println!("{}", writer.emit_il(Some("main".to_owned()), &ssa));
 }


### PR DESCRIPTION
## Rewrite SSA Verifier

The old SSA verifier is not usable, thus I rewrite it. Now the [verifier](https://github.com/radare/radeco-lib/compare/master...ZhangZhuoSJTU:ssa_valid?expand=1#diff-56a685dc39fd98faeda791259b137f4d) could support following check:

+ __Basic Block__: Every basic block could only have _one unconditional outgoing edge_ or _two conditional outgoing edges_.
+ __Expression__
    + Every Opcode node should have the same operands as it need, except for OpCall and OpStore.
    + OpNarrow\(w\)/OpWidth\(w\) nodes should have the same width with w.
    + OpCmp/OpGt/OpLt nodes' width must be 1.
    + OpCall/OpStore/OpLoad do not care about width (for it is not consummate)
    + Other Opcode nodes should have the same width with its every operand (_operands also do not include OpStore/OpLoad_)
+ __Use-Def Chain__
    + Opcode node should not have a back-edge use.
    + Because of Phi, it's possible to have multi-nodes SCC, but it should have at least one operand which is out of this SCC, or to say it _reachable_.

## Bugs

Thanks to this verifier, I found some bugs and fix them.

### Basic Block check

I fix a bug in [phiplacer.rs](https://github.com/radare/radeco-lib/compare/master...ZhangZhuoSJTU:ssa_valid?expand=1#diff-10aa2c91b0a19565e6dd6d1deb61c5c9) at finish point. If the exit block is not the last one we processed, it may make a wrong unconditional edge from some blocks to exit node.

### Expression check

+ In [SCCP](https://github.com/radare/radeco-lib/compare/master...ZhangZhuoSJTU:ssa_valid?expand=1#diff-4cab7417e15745730f917a9b7dded12a), when we emit ssa, we may use a const node to replace an opcode node, which could change the node's width. Thus I add an OpNarrow for the OpConst to adapt width.
+ In SCCP, change OpAdd/OpSub's operation, to avoid integer overflow
+ In phiplacement.rs, when write register, some operations may lead operands' width unbalanced. And also, writing a register into a node with different width should be careful.

### Use-Def Chain check

This fix happened in the last [PR](https://github.com/radare/radeco-lib/pull/69), In add_block function, if we replace node A with node B, but node A is still a variable residence, it may be used after a read_variable, and cause a back-edge use.

## Something need to do

I have add the verify test in most test in tests/, but because I'm not so familiar with grep_and_replace / x86_idioms function, so I haven't add verify into these two. Especially x86_idioms is in backend, I'm not sure whether we should keep width balanced.