### PR TITLE
Rewrite register information for every node

### DIFF
--- a/src/analysis/sccp.rs
+++ b/src/analysis/sccp.rs
@@ -122,7 +122,8 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
             // Even these operands are overdefined.
 
             let edge = self.g.find_edge(&operand_block, &parent_block);
-            if !self.is_executable(&edge) && edge != self.g.invalid_edge() {
+            assert_eq!(edge.len(), 1);
+            if !self.is_executable(&edge[0]) && edge[0] != self.g.invalid_edge() {
                 continue;
             }
             //TODO: Not sure what to do when the edge is invalid

--- a/src/analysis/sccp.rs
+++ b/src/analysis/sccp.rs
@@ -122,6 +122,9 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
             // Even these operands are overdefined.
 
             let edge = self.g.find_edge(&operand_block, &parent_block);
+            if edge.len() == 0 {
+                continue;
+            }
             assert_eq!(edge.len(), 1);
             if !self.is_executable(&edge[0]) && edge[0] != self.g.invalid_edge() {
                 continue;

--- a/src/middle/regfile.rs
+++ b/src/middle/regfile.rs
@@ -14,7 +14,16 @@ use std::convert::From;
 
 use r2api::structs::LRegInfo;
 
-use middle::ssa::ssa_traits::{ValueType, RegInfo};
+use middle::ssa::ssa_traits::ValueType;
+
+
+#[derive(Clone, Debug, Default)]
+pub struct RegInfo {
+    pub name: String,
+    pub type_info: Option<String>,
+    pub alias_info: Option<String>,
+    pub width: Option<usize>,
+}
 
 #[derive(Clone, Copy, Debug)]
 pub struct SubRegister {
@@ -164,6 +173,20 @@ impl SubRegisterFile {
                     return Some(name);
                 }
             }
+        }
+        None
+    }
+
+    pub fn get_reginfo_by_name(&self, name: &String) -> Option<RegInfo> {
+        for id in 0..self.whole_names.len() {
+            if Some(name) == self.get_name(id).as_ref() {
+                return Some(RegInfo {
+                            name: name.clone(),
+                            type_info: self.type_info.get(name).cloned(),
+                            alias_info: self.alias_info.get(name).cloned(),
+                            width: self.get_width(id),
+                });
+            } 
         }
         None
     }

--- a/src/middle/regfile.rs
+++ b/src/middle/regfile.rs
@@ -17,14 +17,6 @@ use r2api::structs::LRegInfo;
 use middle::ssa::ssa_traits::ValueType;
 
 
-#[derive(Clone, Debug, Default)]
-pub struct RegInfo {
-    pub name: String,
-    pub type_info: Option<String>,
-    pub alias_info: Option<String>,
-    pub width: Option<usize>,
-}
-
 #[derive(Clone, Copy, Debug)]
 pub struct SubRegister {
     pub base: usize,
@@ -151,20 +143,6 @@ impl SubRegisterFile {
         }
     }
 
-    pub fn get_reginfo(&self, id: usize) -> Option<RegInfo> {
-        if let Some(name) = self.get_name(id) {
-            Some(RegInfo {
-                name: name.clone(),
-                type_info: self.type_info.get(&name).cloned(),
-                alias_info: self.alias_info.get(&name).cloned(),
-                width: self.get_width(id),
-            })
-        } else {
-            None
-        }
-    }
-
-
     // Get information by other way. 
     pub fn get_name_by_alias(&self, alias: &String) -> Option<String> {
         for id in 0..self.whole_names.len() {
@@ -173,20 +151,6 @@ impl SubRegisterFile {
                     return Some(name);
                 }
             }
-        }
-        None
-    }
-
-    pub fn get_reginfo_by_name(&self, name: &String) -> Option<RegInfo> {
-        for id in 0..self.whole_names.len() {
-            if Some(name) == self.get_name(id).as_ref() {
-                return Some(RegInfo {
-                            name: name.clone(),
-                            type_info: self.type_info.get(name).cloned(),
-                            alias_info: self.alias_info.get(name).cloned(),
-                            width: self.get_width(id),
-                });
-            } 
         }
         None
     }

--- a/src/middle/ssa/cfg_traits.rs
+++ b/src/middle/ssa/cfg_traits.rs
@@ -94,7 +94,7 @@ pub trait CFG {
     }
 
     /// Reference to the edge that connects the source to the target.
-    fn find_edge(&self, source: &Self::ActionRef, target: &Self::ActionRef) -> Self::CFEdgeRef;
+    fn find_edge(&self, source: &Self::ActionRef, target: &Self::ActionRef) -> Vec<Self::CFEdgeRef>;
 
     /// Reference to the true edge
     fn true_edge_of(&self, i: &Self::ActionRef) -> Self::CFEdgeRef;

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -165,6 +165,8 @@ pub trait SSA: CFG {
     /// Get OpCode information, as a pack of get_node_data on a Comment data.
     fn get_opcode(&self, i: &Self::ValueRef) -> Option<ir::MOpcode>;
 
+    /// Get information of the register which belongs to the node.
+    fn get_register(&self, _: &Self::ValueRef) -> Vec<String>;
 
     /// Returns true if the expression acts as a `Selector` for control flow.
     fn is_selector(&self, i: &Self::ValueRef) -> bool;
@@ -273,6 +275,8 @@ pub trait SSAMod: SSA + CFGMod {
     fn map_registers(&mut self, regs: Vec<String>);
 
     fn set_addr(&mut self, &Self::ValueRef, ir::MAddress);
+
+    fn set_register(&mut self, _: Self::ValueRef, _: &String) {  }
 }
 
 /// Extras. TODO
@@ -282,20 +286,11 @@ pub trait SSAMod: SSA + CFGMod {
 /// add any major functionality, but rather just convinence or display glitter, the user must not
 /// be burdened with implementing this. All methods must return `Option<T>` to ensure this.
 
-#[derive(Clone, Debug, Default)]
-pub struct RegInfo {
-    pub name: String,
-    pub type_info: Option<String>,
-    pub alias_info: Option<String>,
-    pub width: Option<usize>,
-}
-
 pub trait SSAExtra: SSA {
     fn mark(&mut self, _: &Self::ValueRef) { }
     fn clear_mark(&mut self, &Self::ValueRef) { }
     fn set_color(&mut self, _: &Self::ValueRef, _: u8) { }
     fn set_comment(&mut self, _: &Self::ValueRef, _: String) { }
-    fn set_register(&mut self, _: &Self::ValueRef, _: RegInfo) {  }
     fn add_flag(&mut self, _: &Self::ValueRef, _: String) { }
     fn is_marked(&self, _: &Self::ValueRef) -> bool {
         false
@@ -310,10 +305,6 @@ pub trait SSAExtra: SSA {
     }
 
     fn addr(&self, _: &Self::ValueRef) -> Option<String> {
-        None
-    }
-
-    fn register(&self, _: &Self::ValueRef) -> Option<RegInfo> {
         None
     }
 

--- a/src/middle/ssa/ssadot.rs
+++ b/src/middle/ssa/ssadot.rs
@@ -136,6 +136,9 @@ impl GraphDot for SSAStorage {
             EdgeData::ReplacedBy => {
                 vec![("color".to_string(), "brown".to_string())]
             }
+            EdgeData::RegisterInfo => {
+                vec![("color".to_string(), "yellow".to_string())]
+            }
             EdgeData::RegisterState => unreachable!(),
         };
 


### PR DESCRIPTION
+ Add register information for every node by adding a new kind of `EdgeData::RegisterInfo` , from value node to corresponding comment node at start_node. 
+ Move register information function from SSAExtra to SSA trait.
+ Make register information automatically change while `replace_node`.
+ Change `find_edge` function to support multiple edges between two same nodes.
+ Change associated code.