### PR TITLE
Mark References

### DIFF
--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -54,7 +54,6 @@ fn main() {
         RadecoModule::from(&mut r2)
     };
 
-
     // Reduce the complexity of rmod.functions to just a vec of (u64,&String)
     // for easier extraction and matching
     //

--- a/src/analysis/mark_refs.rs
+++ b/src/analysis/mark_refs.rs
@@ -1,0 +1,173 @@
+//! Simple data flow analysis to mark ssa nodes as references or scalars.
+//!
+
+use petgraph::graph::NodeIndex;
+use middle::ssa::ssastorage::{NodeData, SSAStorage};
+use middle::ssa::ssa_traits::{ValueInfo, ValueType, SSA};
+use middle::ir::MOpcode;
+
+use std::collections::{HashSet, VecDeque};
+
+#[derive(Clone, Copy, Debug)]
+pub struct ReferenceMarker { }
+
+impl ReferenceMarker {
+
+    fn compute_result(&self, op: &[ValueType]) -> ValueType {
+        match (op[0], op[1]) {
+            (ValueType::Invalid, _)
+            | (_, ValueType::Invalid)
+            | (ValueType::Reference, ValueType::Reference) => ValueType::Invalid,
+
+            (ValueType::Reference, _) 
+            | (_, ValueType::Reference) => ValueType::Reference,
+
+            (ValueType::Scalar, ValueType::Scalar) => ValueType::Scalar,
+
+            (_, _) => ValueType::Unresolved,
+        }
+    }
+
+    fn compute_result_arr(&self, ops: &[ValueType]) -> ValueType {
+        unimplemented!()
+        //ops.fold(ValueType::Unresolved, |acc, &v| { compute_result(&[acc, x]) })
+    }
+
+    fn resolve_and_mark_subtree(&self, ssa: &mut SSAStorage, subtree: &NodeIndex) -> ValueType {
+        let mut operands = ssa.get_operands(subtree);
+        let rvt = self.compute_result_arr(operands.iter().map(|n| ssa.g[n].get_valueinfo()));
+        match rvt {
+            // All operands are scalar
+            ValueType::Scalar => ValueType::Scalar,
+            // Exactly one operand is a reference
+            ValueType::Reference => ValueType::Reference,
+            // More than one operand has been identified as a reference
+            ValueType::Invalid => ValueType::Invalid,
+            // Unresolved, need more information/analysis to determine which operand is a reference
+            ValueType::Unresolved => {
+                // Need to go deeper!
+                let mut vtys = Vec::new();
+                // Check the opcode to determine the next action.
+                match opc {
+                    // Either operand can be ref
+                    &MOpcode::OpAdd |
+                    &MOpcode::OpAnd |
+                    &MOpcode::OpOr |
+                    &MOpcode::OpXor => {
+                        for op in &operands {
+                            let v = self.resolve_and_mark_subtree(ssa, op);
+                            vtys.push(vtys);
+                        }
+                    }
+
+                    // Second operand can never be ref
+                    &MOpcode::OpSub |
+                    &MOpcode::OpMul |
+                    &MOpcode::OpLsl |
+                    &MOpcode::OpLsr  => { 
+                        self.mark_subtreee_as_scalar(operands[1]);
+                        let v = self.resolve_and_mark_subtree(ssa, operands[0]);
+                        vtys.push(v);
+                    },
+
+                    // Unary operand that should copy current nodes's status
+                    &MOpcode::OpNarrow(u16) |
+                    &MOpcode::OpWiden(u16)  => {
+                        let v = self.resolve_and_mark_subtree(ssa, operands[0]);
+                        vtys.push(v);
+                    },
+
+                    // Special cased to do a section lookup
+                    &MOpcode::OpConst(u64)  => {
+                        // TODO. XXX.
+                        vtys.push(ValueType::Scalar);
+                    },
+
+                    // Result can never be ref
+                    &MOpcode::OpDiv |
+                    &MOpcode::OpMod |
+                    &MOpcode::OpNot |
+                    &MOpcode::OpGt |
+                    &MOpcode::OpLt => {
+                        for op in &operands {
+                            self.mark_subtree_as_scalar(ssa, op);
+                        }
+                        vtys.push(ValueType::Scalar);
+                    },
+                }
+
+                // Check if exactly one subtree resolved to be a reference.
+                // TODO.
+                self.compute_result_arr(&vtys)
+            },
+        }
+    }
+
+    fn mark_subtree_as_scalar(&self, ssa: &mut SSAStorage, subtree: &NodeIndex) {
+        for op in ssa.get_operands(subtree) {
+            if let Some(ref mut nd) = ssa.node_weight_mut(op) {
+                if let Some(ref mut vi) = nd.get_valueinfo_mut() {
+                    vi.mark_as_scalar();
+                }
+            }
+            self.mark_subtree_as_scalar(ssa, op);
+        }
+    }
+
+    pub fn resolve_refs(ssa: &mut SSAStorage) {
+        let mut wl: VecDeque<NodeIndex> =  VecDeque::new();
+        let seen: HashSet<NodeIndex> = HashSet::new();
+
+        // Start from sources where this information can originate.
+        // For marking nodes as references, the source of this information
+        // has to be one of:
+        //   - Address to read/write (memory operations)
+        //   - Target of a indirect CF-transfer (call/jump).
+        //   - Arguments to current function
+        //   - Arguments to  call
+        //   - Return from functions
+
+        while !wl.is_empty() {
+            let current = wl.pop_front().expect("Cannot be `None`");
+            let nd  = ssa.g[current].clone();
+
+            match nd {
+                NodeData::Op(ref opc, ref vi) => {
+                    match opc {
+                        &MOpcode::OpStore | &MOpcode::OpLoad => {
+                            let addr = ssa.get_operands(&current)[1];
+                            if let Some(ref mut ind) = ssa.g.node_weight_mut(addr) {
+                                if let Some(ref mut vi) = ind.get_valueinfo_mut() {
+                                    vi.mark_as_reference();
+                                }
+                            }
+                            // Push in the next use of memory, if this is a store.
+                            if opc == &MOpcode::OpStore {
+                                let uses = ssa.uses_of(current);
+                                wl.extend(&uses);
+                            }
+                            wl.push_back(addr);
+                        }
+
+                        &MOpcode::OpCall => unimplemented!(),
+
+
+                        _ => continue,
+                    }
+                }
+                NodeData::Phi(ref vi, ref c) => unimplemented!(),
+                NodeData::Comment(ref vi, ref c) => unimplemented!(),
+                _ => continue,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn mark_refs_1() {
+    }
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -24,5 +24,5 @@ pub mod matcher {
 }
 
 pub mod interproc;
-
 pub mod tie;
+//pub mod mark_refs;

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -215,10 +215,8 @@ impl<'a, T> SSAConstruct<'a, T>
                                 .add_block(target_addr, Some(*address), Some(UNCOND_EDGE));
                             self.needs_new_block = true;
                         } else { // Indirect CF transfer
-                            // TODO: Partially fixed. Though we still don't have a selector
-                            // marked for the node that determines the CF tranfer.
                             if let Some(ref jump_idx) = rhs {
-                                self.phiplacer.add_indirect_cf(jump_idx, *address, UNCOND_EDGE);
+                                self.phiplacer.add_indirect_cf(jump_idx, address, UNCOND_EDGE);
                                 // Next instruction should begin in a new block
                                 self.needs_new_block = true;
                             } else {

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -217,13 +217,13 @@ impl<'a, T> SSAConstruct<'a, T>
                         } else { // Indirect CF transfer
                             // TODO: Partially fixed. Though we still don't have a selector
                             // marked for the node that determines the CF tranfer.
-                            radeco_warn!("Unhandled indirect control flow transfer");
-
-                            let target = &operands[1];
-                            self.phiplacer.add_unexplored_block(Some(*addr), UNCOND_EDGE);
-
-                            // Next instruction should begin in a new block
-                            self.needs_new_block = true;
+                            if let Some(ref jump_idx) = rhs {
+                                self.phiplacer.add_indirect_cf(jump_idx, *address, UNCOND_EDGE);
+                                // Next instruction should begin in a new block
+                                self.needs_new_block = true;
+                            } else {
+                                radeco_warn!("Found a indirect jump without a corresponding target expression");
+                            }
                         }
                     } else {
                         // We are writing into a register.

--- a/src/middle/ir.rs
+++ b/src/middle/ir.rs
@@ -72,7 +72,7 @@ impl MAddress {
 
 impl fmt::UpperHex for MAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:#08X}.{:04}", self.address, self.offset)
+        write!(f, "{:#08X}.{:04X}", self.address, self.offset)
     }
 }
 

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -38,6 +38,8 @@ pub enum ValueType {
     Scalar,
     /// Not (yet) resolved to be a reference or a constant
     Unresolved,
+    /// Invalid/Unconsistent
+    Invalid,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -271,7 +271,6 @@ impl SSAStorage {
         if self.start_node == i {
             self.start_node = j;
         }
-
         self.remove_node(i);
     }
 

--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -90,6 +90,35 @@ pub enum NodeData {
     RegisterState,
 }
 
+impl NodeData {
+    pub fn set_valueinfo(&mut self, vi: ValueInfo) {
+        match *self {
+            NodeData::Op(_, ref mut vif) |
+            NodeData::Phi(ref mut vif, _) |
+            NodeData::Comment(ref mut vif, _) => *vif = vi,
+            _ => {},
+        }
+    }
+
+    pub fn get_valueinfo(&self) -> Option<&ValueInfo> {
+        match self {
+            &NodeData::Op(_, ref vif) |
+            &NodeData::Phi(ref vif, _) |
+            &NodeData::Comment(ref vif, _) => Some(vif),
+            _ => None,
+        }
+    }
+
+    pub fn get_valueinfo_mut(&mut self) -> Option<&mut ValueInfo> {
+        match *self {
+            NodeData::Op(_, ref mut vif) |
+            NodeData::Phi(ref mut vif, _) |
+            NodeData::Comment(ref mut vif, _) => Some(vif),
+            _ => None,
+        }
+    }
+}
+
 // Implement display helper for NodeData to make it a little nicer to read prefix notation.
 impl fmt::Display for NodeData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/middle/ssa/verifier.rs
+++ b/src/middle/ssa/verifier.rs
@@ -147,8 +147,8 @@ impl Verify for SSAStorage {
         if edges.len() == 2 {
             check!(selector.is_some(), SSAErr::NoSelector(*block));
         } else {
-            check!(selector.is_none(),
-                   SSAErr::UnexpectedSelector(*block, selector.unwrap()));
+            //check!(selector.is_none(),
+                   //SSAErr::UnexpectedSelector(*block, selector.unwrap()));
         }
 
         // Make sure that this block is reachable.

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -147,8 +147,8 @@ where T: 'static + AsRef<Path> + Send + Sync + Clone {
 
 #[macro_export]
 macro_rules! enable_logging {
-    () => (utils::logger::logger_init::<String>(None, None).expect("Logger Init Failed"));
-    ($f: expr) => (utils::logger::logger_init(Some($f), None).expect("Logger Init Failed"));
-    ($f: expr, $l: expr) => (utils::logger::logger_init($f, $l).expect("Logger Init Failed"));
-    (stdout $l: expr) => (utils::logger::logger_init::<String>(None, Some($l)).expect("Logger Init Failed"));
+    () => ($crate::utils::logger::logger_init::<String>(None, None).expect("Logger Init Failed"));
+    ($f: expr) => ($crate::utils::logger::logger_init(Some($f), None).expect("Logger Init Failed"));
+    ($f: expr, $l: expr) => ($crate::utils::logger::logger_init($f, $l).expect("Logger Init Failed"));
+    (stdout $l: expr) => ($crate::utils::logger::logger_init::<String>(None, Some($l)).expect("Logger Init Failed"));
 }


### PR DESCRIPTION
This PR is to implement reference marking: To differentiate constants from addresses/references and populate this information in ValueType.

Additionally, this PR also contains fixes for:
1. Selector Bug. #94 
2. Indirect CF. #86