### PR TITLE
Standardize the SSA API

### DIFF
--- a/src/analysis/cse/cse.rs
+++ b/src/analysis/cse/cse.rs
@@ -100,7 +100,7 @@ where I: Iterator<Item = S::ValueRef>,
                 // block.
                 for ex_idx in &ex_idxs {
                     if self.ssa.block_of(*ex_idx) == self.ssa.block_of(expr) {
-                        self.ssa.replace(expr, *ex_idx);
+                        self.ssa.replace_value(expr, *ex_idx);
                         replaced = true;
                         break;
                     }

--- a/src/analysis/cse/cse.rs
+++ b/src/analysis/cse/cse.rs
@@ -40,7 +40,7 @@ where I: Iterator<Item = S::ValueRef>,
     fn hash_args(&self, args: &[S::ValueRef]) -> String {
         let mut result = String::new();
         for arg in args {
-            if let Ok(node_data) = self.ssa.get_node_data(arg) {
+            if let Ok(node_data) = self.ssa.node_data(*arg) {
                 match node_data.nt {
                     NodeType::Op(opc) => {
                         match opc {
@@ -66,9 +66,9 @@ where I: Iterator<Item = S::ValueRef>,
 
     // NOTE: Because we have sorted the operands, it's unnecessary to consider commutative opcodes.
     fn hash_string(&self, idx: &S::ValueRef) -> Option<String> {
-        if let Ok(node_data) = self.ssa.get_node_data(idx) {
+        if let Ok(node_data) = self.ssa.node_data(*idx) {
             if let NodeType::Op(opc) = node_data.nt {
-                let args = self.ssa.args_of(*idx);
+                let args = self.ssa.operands_of(*idx);
                 let hashed_args = self.hash_args(&args);
                 let hs = format!("{}{}", opc, hashed_args);
                 return Some(hs);
@@ -99,7 +99,7 @@ where I: Iterator<Item = S::ValueRef>,
                 // restrict outselves to the case where both the expressions belong to the same
                 // block.
                 for ex_idx in &ex_idxs {
-                    if self.ssa.block_of(ex_idx) == self.ssa.block_of(&expr) {
+                    if self.ssa.block_of(*ex_idx) == self.ssa.block_of(expr) {
                         self.ssa.replace(expr, *ex_idx);
                         replaced = true;
                         break;

--- a/src/analysis/cse/cse.rs
+++ b/src/analysis/cse/cse.rs
@@ -99,7 +99,7 @@ where I: Iterator<Item = S::ValueRef>,
                 // restrict outselves to the case where both the expressions belong to the same
                 // block.
                 for ex_idx in &ex_idxs {
-                    if self.ssa.block_of(*ex_idx) == self.ssa.block_of(expr) {
+                    if self.ssa.block_for(*ex_idx) == self.ssa.block_for(expr) {
                         self.ssa.replace_value(expr, *ex_idx);
                         replaced = true;
                         break;

--- a/src/analysis/cse/ssasort.rs
+++ b/src/analysis/cse/ssasort.rs
@@ -216,8 +216,8 @@ impl<'a, I, T> Sorter<'a, I, T>
                     // always have two operands.
                     assert_eq!(operands.len(), 2);
                     if self.compare(operands[0], operands[1]) == Ordering::Less {
-                        self.ssa.disconnect(&idx, &operands[0]);
-                        self.ssa.disconnect(&idx, &operands[1]);
+                        self.ssa.op_unuse(idx, operands[0]);
+                        self.ssa.op_unuse(idx, operands[1]);
                         self.ssa.op_use(idx, 0, operands[1]);
                         self.ssa.op_use(idx, 1, operands[0]);
                     }

--- a/src/analysis/dom/domtree.rs
+++ b/src/analysis/dom/domtree.rs
@@ -212,8 +212,7 @@ impl DomTree {
 
     pub fn doms(&self, i: graph::NodeIndex) -> Vec<graph::NodeIndex> {
         assert!(self.idom.len() > 0,
-                "Call to DomTree::doms before 
-									  DomTree::build_dom_tree.");
+                "Call to DomTree::doms before DomTree::build_dom_tree.");
 
         let internal_index = self.rmap[&i];
         let mut idom = internal_index;
@@ -229,8 +228,7 @@ impl DomTree {
 
     pub fn idom(&self, i: graph::NodeIndex) -> graph::NodeIndex {
         assert!(self.idom.len() > 0,
-                "Call to DomTree::idom before 
-				DomTree::build_dom_tree.");
+                "Call to DomTree::idom before DomTree::build_dom_tree.");
 
         let internal_index = self.rmap[&i];
         let internal_node = self.idom[internal_index];
@@ -348,8 +346,7 @@ impl DomTree {
 
     pub fn compute_dominance_frontier(&mut self) {
         assert!(self.idom.len() > 0,
-                "Call to DomTree::compute_dominance_frontier 
-				before DomTree::build_dom_tree.");
+                "Call to DomTree::compute_dominance_frontier before DomTree::build_dom_tree.");
 
         let node_count = self.idom.len();
         let mut frontier_map = HashMap::<graph::NodeIndex, HashSet<graph::NodeIndex>>::new();
@@ -386,8 +383,8 @@ impl DomTree {
 /// ////////////////////////////////////////////////////////////////////////////
 
 impl GraphDot for DomTree {
-	type NodeIndex = graph::NodeIndex;
-	type EdgeIndex = u8;
+    type NodeIndex = graph::NodeIndex;
+    type EdgeIndex = u8;
 
     fn node_count(&self) -> usize {
         self.g.node_count()

--- a/src/analysis/dom/index.rs
+++ b/src/analysis/dom/index.rs
@@ -55,7 +55,7 @@ impl Hash for InternalIndex {
 impl Eq for InternalIndex { }
 
 impl Index<InternalIndex> for Vec<InternalIndex> {
-	type Output = InternalIndex;
+    type Output = InternalIndex;
     fn index(&self, index: InternalIndex) -> &InternalIndex {
         &self[index.index]
     }

--- a/src/analysis/interproc/digstack.rs
+++ b/src/analysis/interproc/digstack.rs
@@ -27,7 +27,7 @@ pub fn backward_analysis(ssa:&SSAStorage, sp_name: String)
     let mut visited: HashSet<LValueRef> = HashSet::new();
 
     // Initial the last SP register offset to ZERO.
-    let reg_state = ssa.registers_at(&ssa.exit_node());
+    let reg_state = ssa.registers_at(&ssa.exit_node().expect("Incomplete CFG graph"));
     let nodes = ssa.args_of(reg_state);
     for node in &nodes {
         if ssa.get_register(node).contains(&sp_name) {
@@ -132,7 +132,7 @@ fn generic_frontward_analysis(ssa: &SSAStorage,
         -> HashMap<LValueRef, i64> {
     let mut stack_offset: HashMap<LValueRef, i64> = HashMap::new();
     {
-        let reg_state = ssa.registers_at(&ssa.entry_node());
+        let reg_state = ssa.registers_at(&ssa.entry_node().expect("Incomplete CFG graph"));
         let nodes = ssa.args_of(reg_state);
         for node in &nodes {
             if ssa.get_comment(node) != Some(sp_name.clone()) {
@@ -151,7 +151,7 @@ fn generic_frontward_analysis(ssa: &SSAStorage,
         }
         nodes
     } else {
-        let blocks = ssa.succs_of(ssa.entry_node());
+        let blocks = ssa.succs_of(ssa.entry_node().expect("Incomplete CFG graph"));
         assert_eq!(blocks.len(), 1);
         ssa.exprs_in(&blocks[0])
     };

--- a/src/analysis/interproc/digstack.rs
+++ b/src/analysis/interproc/digstack.rs
@@ -132,7 +132,7 @@ fn generic_frontward_analysis(ssa: &SSAStorage,
         -> HashMap<LValueRef, i64> {
     let mut stack_offset: HashMap<LValueRef, i64> = HashMap::new();
     {
-        let reg_state = ssa.registers_at(&ssa.start_node());
+        let reg_state = ssa.registers_at(&ssa.entry_node());
         let nodes = ssa.args_of(reg_state);
         for node in &nodes {
             if ssa.get_comment(node) != Some(sp_name.clone()) {
@@ -151,7 +151,7 @@ fn generic_frontward_analysis(ssa: &SSAStorage,
         }
         nodes
     } else {
-        let blocks = ssa.succs_of(ssa.start_node());
+        let blocks = ssa.succs_of(ssa.entry_node());
         assert_eq!(blocks.len(), 1);
         ssa.exprs_in(&blocks[0])
     };

--- a/src/analysis/interproc/fixcall.rs
+++ b/src/analysis/interproc/fixcall.rs
@@ -355,7 +355,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             -> HashMap<String, i64> {
         let mut entry_store: HashMap<String, i64> = HashMap::new();
 
-        let reg_state = ssa.registers_at(&ssa.start_node());
+        let reg_state = ssa.registers_at(&ssa.entry_node());
         let nodes = ssa.args_of(reg_state);
         for node in &nodes {
             if ssa.get_comment(node).is_none(){

--- a/src/analysis/interproc/fixcall.rs
+++ b/src/analysis/interproc/fixcall.rs
@@ -296,7 +296,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
         let mut worklist: VecDeque<LValueRef> = VecDeque::new();
         let mut visited: HashSet<LValueRef> = HashSet::new();
 
-        let reg_state = ssa.registers_at(&ssa.exit_node());
+        let reg_state = ssa.registers_at(&ssa.exit_node().expect("Incomplete CFG graph"));
         worklist.push_back(reg_state);
         
         while let Some(node) = worklist.pop_front() {
@@ -355,7 +355,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
             -> HashMap<String, i64> {
         let mut entry_store: HashMap<String, i64> = HashMap::new();
 
-        let reg_state = ssa.registers_at(&ssa.entry_node());
+        let reg_state = ssa.registers_at(&ssa.entry_node().expect("Incomplete CFG graph"));
         let nodes = ssa.args_of(reg_state);
         for node in &nodes {
             if ssa.get_comment(node).is_none(){

--- a/src/analysis/interproc/fixcall.rs
+++ b/src/analysis/interproc/fixcall.rs
@@ -224,7 +224,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
                         continue;
                     }
 
-                    ssa.replace(replace_pair[1], replace_pair[0]);
+                    ssa.replace_value(replace_pair[1], replace_pair[0]);
                 }
             }
         }

--- a/src/analysis/interproc/summary.rs
+++ b/src/analysis/interproc/summary.rs
@@ -39,7 +39,7 @@ impl<'a, T: RModule<'a>> InterProcAnalysis<'a, T> for CallSummary {
             {
                 let locals = rfn.locals().iter().map(|x| x.0).collect::<HashSet<_>>();
                 let ssa = rfn.ssa_ref();
-                let start_block = ssa.entry_node();
+                let start_block = ssa.entry_node().expect("Incomplete CFG graph");
                 // Get register state at the start block.
                 let rs = ssa.registers_at(&start_block);
                 // For every register in the starting block.
@@ -68,7 +68,7 @@ impl<'a, T: RModule<'a>> InterProcAnalysis<'a, T> for CallSummary {
                         }
                     }
                 }
-                let exit_block = ssa.exit_node();
+                let exit_block = ssa.exit_node().expect("Incomplete CFG graph");
                 let rs = ssa.registers_at(&exit_block);
                 for (i, r) in ssa.args_of(rs).iter().enumerate() {
                     let (insert_r, insert_m) = if let Ok(ref data) = ssa.get_node_data(r) {

--- a/src/analysis/interproc/summary.rs
+++ b/src/analysis/interproc/summary.rs
@@ -39,7 +39,7 @@ impl<'a, T: RModule<'a>> InterProcAnalysis<'a, T> for CallSummary {
             {
                 let locals = rfn.locals().iter().map(|x| x.0).collect::<HashSet<_>>();
                 let ssa = rfn.ssa_ref();
-                let start_block = ssa.start_node();
+                let start_block = ssa.entry_node();
                 // Get register state at the start block.
                 let rs = ssa.registers_at(&start_block);
                 // For every register in the starting block.

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -493,7 +493,7 @@ mod test {
         let const_2 = ssa.add_const(2);
         ssa.op_use(add, 0, const_1);
         ssa.op_use(add, 1, const_2);
-        ssa.mark_start_node(&add);
+        ssa.mark_entry_node(&add);
         let _ = ssa.add_op(MOpcode::OpAdd, vt, None);
         let m = grep!(&mut ssa, "(OpAdd #x1, #x2)");
         assert_eq!(m[0].root.index(), 0);
@@ -507,7 +507,7 @@ mod test {
         let const_1 = ssa.add_const(1);
         ssa.op_use(add, 0, const_1);
         ssa.op_use(add, 1, const_1);
-        ssa.mark_start_node(&add);
+        ssa.mark_entry_node(&add);
         let m = grep!(&mut ssa, "(OpXor %1, %1)");
         assert_eq!(m[0].root.index(), 0);
         assert_eq!(m[0].bindings[0].0, "%1");
@@ -529,7 +529,7 @@ mod test {
             ssa.add_to_block(const_2, blk, addr);
             ssa.op_use(add, 0, const_1);
             ssa.op_use(add, 1, const_2);
-            ssa.mark_start_node(&blk);
+            ssa.mark_entry_node(&blk);
         }
 
         grep_and_replace!(&mut ssa, "(OpAdd %1, %2)" => "(OpSub %1, %2)");

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -366,7 +366,7 @@ where I: Iterator<Item=S::ValueRef>,
         // Remove operands to the root node and prepare for replace.
         let root = found.root;
         let mut address = self.ssa.address(root).expect("No address information found");
-        let block = self.ssa.block_of(root).expect("Value node doesn't belong to any block");
+        let block = self.ssa.block_for(root).expect("Value node doesn't belong to any block");
 
         // Now we have a root node with no args, but retaining its uses.
         // Replace this node with the root node in the replace expression.

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -493,7 +493,7 @@ mod test {
         let const_2 = ssa.add_const(2);
         ssa.op_use(add, 0, const_1);
         ssa.op_use(add, 1, const_2);
-        ssa.mark_entry_node(&add);
+        ssa.set_entry_node(add);
         let _ = ssa.add_op(MOpcode::OpAdd, vt, None);
         let m = grep!(&mut ssa, "(OpAdd #x1, #x2)");
         assert_eq!(m[0].root.index(), 0);
@@ -507,7 +507,7 @@ mod test {
         let const_1 = ssa.add_const(1);
         ssa.op_use(add, 0, const_1);
         ssa.op_use(add, 1, const_1);
-        ssa.mark_entry_node(&add);
+        ssa.set_entry_node(add);
         let m = grep!(&mut ssa, "(OpXor %1, %1)");
         assert_eq!(m[0].root.index(), 0);
         assert_eq!(m[0].bindings[0].0, "%1");
@@ -518,7 +518,7 @@ mod test {
     fn simple_grep_replace1() {
         let mut ssa = SSAStorage::new();
         {
-            let blk = ssa.add_dynamic();
+            let blk = ssa.insert_dynamic().expect("Cannot insert new dynamics");
             let vt = ValueInfo::new_unresolved(WidthSpec::from(64));
             let add = ssa.add_op(MOpcode::OpAdd, vt, None);
             let const_1 = ssa.add_const(1);
@@ -529,7 +529,7 @@ mod test {
             ssa.add_to_block(const_2, blk, addr);
             ssa.op_use(add, 0, const_1);
             ssa.op_use(add, 1, const_2);
-            ssa.mark_entry_node(&blk);
+            ssa.set_entry_node(blk);
         }
 
         grep_and_replace!(&mut ssa, "(OpAdd %1, %2)" => "(OpSub %1, %2)");

--- a/src/analysis/propagate/data.rs
+++ b/src/analysis/propagate/data.rs
@@ -6,5 +6,5 @@
 // except according to those terms.
 
 pub trait DataOperator<T> {
-	fn join(inputs: &[T]) -> T;
+    fn join(inputs: &[T]) -> T;
 }

--- a/src/analysis/sccp.rs
+++ b/src/analysis/sccp.rs
@@ -111,9 +111,9 @@ impl<T> Analyzer<T>
         }
 
         let invalid_block = self.g.invalid_action().expect("Invalid Action is not defind");
-        let parent_block = self.g.block_of(*i).unwrap_or(invalid_block);
+        let parent_block = self.g.block_for(*i).unwrap_or(invalid_block);
         for op in &operands {
-            let operand_block = self.g.block_of(*op).unwrap_or(invalid_block);
+            let operand_block = self.g.block_for(*op).unwrap_or(invalid_block);
             let op_val = self.get_value(op);
 
             if op_val.is_undefined() {
@@ -388,7 +388,7 @@ impl<T> Analyzer<T>
 
             while let Some(e) = self.ssa_worklist.pop_front() {
                 let t = if self.g.is_expr(e) {
-                    let block_of = self.g.block_of(e)
+                    let block_of = self.g.block_for(e)
                                             .expect("Value node doesn't belong to any block");
                     if self.is_block_executable(&block_of) {
                         self.visit_expression(&e)
@@ -519,7 +519,7 @@ impl<T> Analyzer<T>
         if !self.g.is_expr(*i) {
             return;
         }
-        let owner_block = self.g.block_of(*i)
+        let owner_block = self.g.block_for(*i)
                                 .expect("Value node doesn't belong to any block");
         if self.is_block_executable(&owner_block) {
             self.ssa_worklist.push_back(*i);

--- a/src/analysis/sccp.rs
+++ b/src/analysis/sccp.rs
@@ -321,8 +321,8 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
     pub fn analyze(&mut self) {
 
         {
-            let start_node = self.g.start_node();
-            let edges = self.g.edges_of(&start_node);
+            let entry_node = self.g.entry_node();
+            let edges = self.g.edges_of(&entry_node);
             for &(ref next, _) in &edges {
                 self.cfgwl_push(next);
             }
@@ -477,8 +477,8 @@ impl<T: SSA + SSAMod + Clone> Analyzer<T> {
     }
 
     fn is_block_executable(&self, i: &T::ActionRef) -> bool {
-        // start_node is always reachable.
-        if *i == self.g.start_node() {
+        // entry_node is always reachable.
+        if *i == self.g.entry_node() {
             return true;
         }
         let incoming = self.g.incoming_edges(i);

--- a/src/analysis/valueset/knownbits.rs
+++ b/src/analysis/valueset/knownbits.rs
@@ -68,7 +68,7 @@ impl KnownBits {
 }
 
 impl<'a, 'b> BitAnd<&'a KnownBits> for &'b KnownBits {
-	type Output = KnownBits;
+    type Output = KnownBits;
 
     fn bitand(self, rhs: &KnownBits) -> KnownBits {
         KnownBits {
@@ -79,7 +79,7 @@ impl<'a, 'b> BitAnd<&'a KnownBits> for &'b KnownBits {
 }
 
 impl<'a, 'b> BitOr<&'a KnownBits> for &'b KnownBits {
-	type Output = KnownBits;
+    type Output = KnownBits;
 
     fn bitor(self, rhs: &KnownBits) -> KnownBits {
         KnownBits {

--- a/src/analysis/valueset/sintrange.rs
+++ b/src/analysis/valueset/sintrange.rs
@@ -67,7 +67,7 @@ impl SIntRange {
 }
 
 impl<'a, 'b> BitAnd<&'a SIntRange> for &'b SIntRange {
-	type Output = SIntRange;
+    type Output = SIntRange;
 
     fn bitand(self, rhs: &SIntRange) -> SIntRange {
         SIntRange {
@@ -78,7 +78,7 @@ impl<'a, 'b> BitAnd<&'a SIntRange> for &'b SIntRange {
 }
 
 impl<'a, 'b> BitOr<&'a SIntRange> for &'b SIntRange {
-	type Output = SIntRange;
+    type Output = SIntRange;
 
     fn bitor(self, rhs: &SIntRange) -> SIntRange {
         SIntRange {

--- a/src/analysis/valueset/strided_interval.rs
+++ b/src/analysis/valueset/strided_interval.rs
@@ -321,7 +321,7 @@ impl StridedInterval {
 }
 
 impl<'a, 'b> BitAnd<&'a StridedInterval> for &'b StridedInterval {
-	type Output = StridedInterval;
+    type Output = StridedInterval;
 
     fn bitand(self, rhs: &StridedInterval) -> StridedInterval {
         StridedInterval {
@@ -332,7 +332,7 @@ impl<'a, 'b> BitAnd<&'a StridedInterval> for &'b StridedInterval {
 }
 
 impl<'a, 'b> BitOr<&'a StridedInterval> for &'b StridedInterval {
-	type Output = StridedInterval;
+    type Output = StridedInterval;
 
     fn bitor(self, rhs: &StridedInterval) -> StridedInterval {
         StridedInterval {

--- a/src/analysis/valueset/uintmultiple.rs
+++ b/src/analysis/valueset/uintmultiple.rs
@@ -81,7 +81,7 @@ impl UIntMultiple {
 }
 
 impl<'a, 'b> BitAnd<&'a UIntMultiple> for &'b UIntMultiple {
-	type Output = UIntMultiple;
+    type Output = UIntMultiple;
 
     fn bitand(self, rhs: &UIntMultiple) -> UIntMultiple {
         // calls the euclidean algorithm three times
@@ -132,7 +132,7 @@ impl<'a, 'b> BitAnd<&'a UIntMultiple> for &'b UIntMultiple {
 }
 
 impl<'a, 'b> BitOr<&'a UIntMultiple> for &'b UIntMultiple {
-	type Output = UIntMultiple;
+    type Output = UIntMultiple;
 
     fn bitor(self, rhs: &UIntMultiple) -> UIntMultiple {
 

--- a/src/analysis/valueset/uintrange.rs
+++ b/src/analysis/valueset/uintrange.rs
@@ -36,7 +36,7 @@ impl UIntRange {
 }
 
 impl<'a, 'b> BitAnd<&'a UIntRange> for &'b UIntRange {
-	type Output = UIntRange;
+    type Output = UIntRange;
 
     fn bitand(self, rhs: &UIntRange) -> UIntRange {
         UIntRange {
@@ -47,7 +47,7 @@ impl<'a, 'b> BitAnd<&'a UIntRange> for &'b UIntRange {
 }
 
 impl<'a, 'b> BitOr<&'a UIntRange> for &'b UIntRange {
-	type Output = UIntRange;
+    type Output = UIntRange;
 
     fn bitor(self, rhs: &UIntRange) -> UIntRange {
         UIntRange {

--- a/src/backend/scf/dream.rs
+++ b/src/backend/scf/dream.rs
@@ -12,124 +12,124 @@ use super::{AST, AST_};
 use analysis::dom::DomInfo;
 
 struct GraphSlice<T> {
-	source: NodeIndex,
-	sink:   NodeIndex,
-	graph:  Graph<NodeIndex. EdgeIndex>
+    source: NodeIndex,
+    sink:   NodeIndex,
+    graph:  Graph<NodeIndex. EdgeIndex>
 }
 
 impl GraphSlice {
-	fn from()
+    fn from()
 }
 
 enum Marker {
-	Unvisited,
-	Visited,
-	VisitedOnStack,
-	VisitedCycle,
-	VisitedOnStackCycle,
+    Unvisited,
+    Visited,
+    VisitedOnStack,
+    VisitedCycle,
+    VisitedOnStackCycle,
 }
 
 impl Marker {
-	fn cycle(&self) -> Self { match *self {
-		VisitedOnStack | VisitedOnStackCycle => true,
-		_ => false
-	}}
-	fn visited(&self) -> Self { match *self {
-		Unvisited => false,
-		_ => true
-	}}
-	fn push(&mut self) -> bool {
-		let descend = !self.visited();
-		*self = match *self {
-			Unvisited           => VisitedOnStack,
-			Visited             => VisitedOnStack,
-			VisitedOnStack      => VisitedOnStackCycle,
-			VisitedCycle        => VisitedCycle,
-			VisitedOnStackCycle => VisitedOnStackCycle,
-		};
-		descend
-	}
-	fn pop(&mut self) {
-		*self = match *self {
-			Unvisited           => panic!(),
-			Visited             => panic!(),
-			VisitedOnStack      => Visited,
-			VisitedCycle        => VisitedCycle,
-			VisitedOnStackCycle => VisitedCycle,
-		};
-	}
+    fn cycle(&self) -> Self { match *self {
+        VisitedOnStack | VisitedOnStackCycle => true,
+        _ => false
+    }}
+    fn visited(&self) -> Self { match *self {
+        Unvisited => false,
+        _ => true
+    }}
+    fn push(&mut self) -> bool {
+        let descend = !self.visited();
+        *self = match *self {
+            Unvisited           => VisitedOnStack,
+            Visited             => VisitedOnStack,
+            VisitedOnStack      => VisitedOnStackCycle,
+            VisitedCycle        => VisitedCycle,
+            VisitedOnStackCycle => VisitedOnStackCycle,
+        };
+        descend
+    }
+    fn pop(&mut self) {
+        *self = match *self {
+            Unvisited           => panic!(),
+            Visited             => panic!(),
+            VisitedOnStack      => Visited,
+            VisitedCycle        => VisitedCycle,
+            VisitedOnStackCycle => VisitedCycle,
+        };
+    }
 }
 
 struct BB<T: SSA> {
-	index:    T::ActionRef,
-	ast:      Option<AST_<T::ActionRef, T::ValueRef>>,
-	selector: Option<T::ValueRef>,
+    index:    T::ActionRef,
+    ast:      Option<AST_<T::ActionRef, T::ValueRef>>,
+    selector: Option<T::ValueRef>,
 }
 
 type CFG<T: SSA> = Graph<BB, u8>;
 
 struct CFG2<T: SSA> {
-	// TODO: better name
-	cfg:        CFG<T>
-	markers:    Vec<Marker>,
-	post_order: Vec<NodeIndex>
+    // TODO: better name
+    cfg:        CFG<T>
+    markers:    Vec<Marker>,
+    post_order: Vec<NodeIndex>
 }
 
 impl CFG2<T: SSA> {
-	fn build_cfg<T: SSA>(ssa: &T) -> CFG<T> {
-		let cfg = Graph::new();
+    fn build_cfg<T: SSA>(ssa: &T) -> CFG<T> {
+        let cfg = Graph::new();
 
-	}
+    }
 
-	fn dfs<T: SSA>(cfg: &mut CFG<T>, i: NodeIndex) {
-		let descend = (&mut cfg[i]).push();
-		if descend {
-			self.post_order.push(i);
+    fn dfs<T: SSA>(cfg: &mut CFG<T>, i: NodeIndex) {
+        let descend = (&mut cfg[i]).push();
+        if descend {
+            self.post_order.push(i);
 
-		}
-		(&mut cfg[i]).pop();
-	}
+        }
+        (&mut cfg[i]).pop();
+    }
 }
 
 struct Dreamer<T: SSA> {
-	ssa:     &T,
-	cfg:     &mut CFG<T>,
-	dominfo: DomInfo,
+    ssa:     &T,
+    cfg:     &mut CFG<T>,
+    dominfo: DomInfo,
 }
 
 impl<T: SSA> Dreamer<T> {
-	pub fn new(ssa: &T) -> Self {
-		let mut d = Dreamer {
-			ssa:     ssa,
-			cfg:     build_cfg(ssa),
-			domtree: DomInfo::new(),
-		};
-		d.build_dom_tree(ssa, ssa.start_node())
-	}
+    pub fn new(ssa: &T) -> Self {
+        let mut d = Dreamer {
+            ssa:     ssa,
+            cfg:     build_cfg(ssa),
+            domtree: DomInfo::new(),
+        };
+        d.build_dom_tree(ssa, ssa.start_node())
+    }
 
-	fn acyclic_region(&mut self) {
+    fn acyclic_region(&mut self) {
 
-	}
+    }
 
-	fn cyclic_region(&mut self) {
-		unimplemented!();
-	}
+    fn cyclic_region(&mut self) {
+        unimplemented!();
+    }
 
-	fn dfs(&mut self, i: NodeIndex) {
+    fn dfs(&mut self, i: NodeIndex) {
 
-		let direction = EdgeDirection::Outgoing;
-		let neighbors_iter = g.neighbors_directed(node, direction)
-			.collect::<Vec<NodeIndex>>();
+        let direction = EdgeDirection::Outgoing;
+        let neighbors_iter = g.neighbors_directed(node, direction)
+            .collect::<Vec<NodeIndex>>();
 
-		for n in neighbors_iter.iter() {
-			self.dfs(g, n.clone());
-		}
+        for n in neighbors_iter.iter() {
+            self.dfs(g, n.clone());
+        }
 
-		self.visited.push(node.clone());
-		self.post_order.push(node.clone());	
-	}
+        self.visited.push(node.clone());
+        self.post_order.push(node.clone());    
+    }
 
-	pub fn run(&mut self) {
+    pub fn run(&mut self) {
 
-	}
+    }
 }

--- a/src/frontend/containers.rs
+++ b/src/frontend/containers.rs
@@ -187,8 +187,9 @@ fn fix_call_info(rfn: &mut DefaultFnTy) {
                                     .address;
                 if let Some(info) = call_info.get_mut(&call_site) {
                     if let Some(arg_node) = ssa.operands_of(*call_node).get(0) {
-                        let target_node = ssa.add_const(info.callee.unwrap());
-                        ssa.disconnect(call_node, arg_node);
+                        let target_node = ssa.insert_const(info.callee.unwrap())
+                                                .expect("Cannot insert new constants");
+                        ssa.op_unuse(*call_node, *arg_node);
                         ssa.op_use(*call_node, 0, target_node);
                         info.ssa_ref = Some(*call_node);
                     }

--- a/src/frontend/containers.rs
+++ b/src/frontend/containers.rs
@@ -242,7 +242,7 @@ fn analyze_memory(rfn: &mut DefaultFnTy) {
         let name = rfn.name.clone();
         let ssa = rfn.ssa_mut();
         let mem = {
-            let start = ssa.start_node();
+            let start = ssa.entry_node();
             let rs = ssa.registers_at(&start);
             // mem is the first argument for the register state.
             // NOTE: If something changes in the future, the above assumption may no longer be
@@ -360,7 +360,7 @@ impl<'a, T: 'a + Source> From<&'a mut T> for RadecoModule<'a, DefaultFnTy> {
                     // Add all defined registers to bindings.
                     let regs = {
                         let ssa = rfn.ssa_mut();
-                        let start = ssa.start_node();
+                        let start = ssa.entry_node();
                         let rs = ssa.registers_at(&start);
                         ssa.args_of(rs)
                     };

--- a/src/frontend/containers.rs
+++ b/src/frontend/containers.rs
@@ -242,7 +242,7 @@ fn analyze_memory(rfn: &mut DefaultFnTy) {
         let name = rfn.name.clone();
         let ssa = rfn.ssa_mut();
         let mem = {
-            let start = ssa.entry_node();
+            let start = ssa.entry_node().expect("Incomplete CFG graph");
             let rs = ssa.registers_at(&start);
             // mem is the first argument for the register state.
             // NOTE: If something changes in the future, the above assumption may no longer be
@@ -360,7 +360,7 @@ impl<'a, T: 'a + Source> From<&'a mut T> for RadecoModule<'a, DefaultFnTy> {
                     // Add all defined registers to bindings.
                     let regs = {
                         let ssa = rfn.ssa_mut();
-                        let start = ssa.entry_node();
+                        let start = ssa.entry_node().expect("Incomplete CFG graph");
                         let rs = ssa.registers_at(&start);
                         ssa.args_of(rs)
                     };

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -391,7 +391,7 @@ impl<'a, T> SSAConstruct<'a, T>
         let start_address = MAddress::new(0, 0);
         let start_block = self.phiplacer.add_block(start_address, None, None);
 
-        self.phiplacer.mark_start_node(&start_block);
+        self.phiplacer.mark_entry_node(&start_block);
 
         for (i, name) in self.regfile.whole_names.iter().enumerate() {
             let reg = self.regfile.whole_registers.get(i).expect("This cannot be `None`");

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -25,6 +25,7 @@ use middle::ir::{self, MAddress, MOpcode};
 use middle::phiplacement::PhiPlacer;
 use middle::regfile::SubRegisterFile;
 use middle::ssa::ssa_traits::{SSAExtra, SSAMod, ValueInfo};
+use middle::ssa::graph_traits::Graph;
 
 pub type VarId = usize;
 
@@ -33,7 +34,10 @@ const TRUE_EDGE: u8 = 1;
 const UNCOND_EDGE: u8 = 2;
 
 pub struct SSAConstruct<'a, T>
-    where T: 'a + Clone + fmt::Debug + SSAMod<BBInfo = MAddress> + SSAExtra
+    where T: 'a + Clone + fmt::Debug + SSAExtra +
+        SSAMod<BBInfo = MAddress,
+                ActionRef = <T as Graph>::GraphNodeRef,
+                CFEdgeRef = <T as Graph>::GraphEdgeRef>
 {
     phiplacer: PhiPlacer<'a, T>,
     regfile: SubRegisterFile,
@@ -53,10 +57,10 @@ pub struct SSAConstruct<'a, T>
 }
 
 impl<'a, T> SSAConstruct<'a, T>
-    where T: 'a + Clone
-    + fmt::Debug
-    + SSAExtra
-    + SSAMod<BBInfo=MAddress, ValueRef=NodeIndex, ActionRef=NodeIndex>
+    where T: 'a + Clone + fmt::Debug + SSAExtra +
+        SSAMod<BBInfo = MAddress,
+                ActionRef = <T as Graph>::GraphNodeRef,
+                CFEdgeRef = <T as Graph>::GraphEdgeRef>
 {
     pub fn new(ssa: &'a mut T, reg_info: &LRegInfo) -> SSAConstruct<'a, T> {
         let regfile = SubRegisterFile::new(reg_info);

--- a/src/middle/dce.rs
+++ b/src/middle/dce.rs
@@ -64,7 +64,7 @@ pub fn sweep<T>(ssa: &mut T)
 {
     for node in &ssa.values() {
         if !ssa.is_marked(node) {
-            ssa.remove(*node);
+            ssa.remove_value(*node);
         }
         ssa.clear_mark(node);
     }

--- a/src/middle/dce.rs
+++ b/src/middle/dce.rs
@@ -22,7 +22,7 @@ pub fn collect<T: Clone + SSAMod + SSAExtra>(ssa: &mut T) {
 
 /// Marks node for removal. This method does not remove nodes
 pub fn mark<T: Clone + SSAMod + SSAExtra>(ssa: &mut T) {
-    let nodes = ssa.nodes();
+    let nodes = ssa.values();
     let exit_node = ssa.exit_node();
     let roots = ssa.registers_at(&exit_node);
     let mut queue = VecDeque::<T::ValueRef>::new();
@@ -50,7 +50,7 @@ pub fn mark<T: Clone + SSAMod + SSAExtra>(ssa: &mut T) {
 
 /// Sweeps away the un-marked nodes
 pub fn sweep<T: Clone + SSAMod + SSAExtra>(ssa: &mut T) {
-    for node in &ssa.nodes() {
+    for node in &ssa.values() {
         if !ssa.is_marked(node) {
             ssa.remove(*node);
         }
@@ -61,7 +61,7 @@ pub fn sweep<T: Clone + SSAMod + SSAExtra>(ssa: &mut T) {
     let blocks = ssa.blocks();
     for block in &blocks {
         // Do not touch start or exit nodes
-        if *block == ssa.start_node() || *block == ssa.exit_node() {
+        if *block == ssa.entry_node() || *block == ssa.exit_node() {
             continue;
         }
 

--- a/src/middle/dce.rs
+++ b/src/middle/dce.rs
@@ -88,7 +88,7 @@ pub fn sweep<T>(ssa: &mut T)
                     for &(ie, ref i) in &incoming {
                         let new_src = ssa.edge_info(ie).expect("Less-endpoints edge").source;
                         ssa.remove_control_edge(ie);
-                        ssa.add_control_edge(new_src, new_target, *i);
+                        ssa.insert_control_edge(new_src, new_target, *i);
                     }
                     ssa.remove_control_edge(outgoing[0].0);
                     true

--- a/src/middle/dot.rs
+++ b/src/middle/dot.rs
@@ -17,15 +17,15 @@ use petgraph::graph::NodeIndex;
 
 #[allow(unused_macros)]
 macro_rules! add_strings {
-	( $( $x: expr ),* ) => {
-		{
-			let mut s = String::new();
-			$(
-				s.push_str(&format!("{}", $x));
-			 )*
-				s
-		}
-	};
+    ( $( $x: expr ),* ) => {
+        {
+            let mut s = String::new();
+            $(
+                s.push_str(&format!("{}", $x));
+             )*
+                s
+        }
+    };
 }
 
 /// Represents the contents of a `GraphViz` attribute block
@@ -93,8 +93,8 @@ impl Index for NodeIndex {
 
 /// This trait enables graphs to be generated from implementors.
 pub trait GraphDot {
-	type NodeIndex: Hash + Clone + Eq + Index + Debug;
-	type EdgeIndex: Hash + Clone + Eq;
+    type NodeIndex: Hash + Clone + Eq + Index + Debug;
+    type EdgeIndex: Hash + Clone + Eq;
 
     fn node_index_new(usize) -> Self::NodeIndex;
     fn edge_index_new(usize) -> Self::EdgeIndex;

--- a/src/middle/mod.rs
+++ b/src/middle/mod.rs
@@ -16,6 +16,7 @@ pub mod regfile;
 
 #[macro_use]
 pub mod ssa {
+    pub mod graph_traits;
     pub mod cfg_traits;
     #[macro_use] pub mod ssa_traits;
     pub mod ssastorage;

--- a/src/middle/phiplacement.rs
+++ b/src/middle/phiplacement.rs
@@ -505,8 +505,8 @@ impl<'a, T: SSAMod<BBInfo=MAddress> + SSAExtra +  'a> PhiPlacer<'a, T> {
         }
     }
 
-    pub fn mark_start_node(&mut self, block: &T::ActionRef) {
-        self.ssa.mark_start_node(block);
+    pub fn mark_entry_node(&mut self, block: &T::ActionRef) {
+        self.ssa.mark_entry_node(block);
     }
 
     pub fn mark_exit_node(&mut self, block: &T::ActionRef) {
@@ -771,7 +771,7 @@ impl<'a, T: SSAMod<BBInfo=MAddress> + SSAExtra +  'a> PhiPlacer<'a, T> {
     pub fn block_of(&self, address: MAddress) -> Option<T::ActionRef> {
         let mut last = None;
         let start_address = {
-            let start = self.ssa.start_node();
+            let start = self.ssa.entry_node();
             self.addr_of(&start)
         };
         for (baddr, index) in self.blocks.iter().rev() {
@@ -857,16 +857,16 @@ impl<'a, T: SSAMod<BBInfo=MAddress> + SSAExtra +  'a> PhiPlacer<'a, T> {
             self.seal_block(*block);
         }
 
-        for node in self.ssa.nodes() {
-            if let Some(addr) = self.index_to_addr.get(&node).cloned() {
-                self.associate_block(&node, addr);
+        for node in &self.ssa.values() {
+            if let Some(addr) = self.index_to_addr.get(node).cloned() {
+                self.associate_block(node, addr);
                 // Mark selector.
-                if let Ok(ndata) = self.ssa.get_node_data(&node) {
+                if let Ok(ndata) = self.ssa.get_node_data(node) {
                     if let NodeType::Op(MOpcode::OpITE) = ndata.nt {
                         let block = self.block_of(addr);
-                        let cond_node = self.ssa.get_operands(&node)[0];
+                        let cond_node = self.ssa.get_operands(node)[0];
                         self.ssa.mark_selector(cond_node, block.unwrap());
-                        self.ssa.remove(node);
+                        self.ssa.remove(*node);
                     }
                 }
             }

--- a/src/middle/ssa/cfg_traits.rs
+++ b/src/middle/ssa/cfg_traits.rs
@@ -106,22 +106,23 @@ pub trait CFGMod: CFG {
 	type BBInfo;
 
     /// Mark the start node for the SSA graph
-    fn mark_entry_node(&mut self, start: &Self::ActionRef);
+    fn set_entry_node(&mut self, start: Self::ActionRef);
 
     /// Mark the exit node for the SSA graph
-    fn mark_exit_node(&mut self, exit: &Self::ActionRef);
+    fn set_exit_node(&mut self, exit: Self::ActionRef);
 
-    /// Add a new basic block
-    fn add_block(&mut self, info: Self::BBInfo) -> Self::ActionRef;
+    /// Insert a new basic block
+    fn insert_block(&mut self, info: Self::BBInfo) -> Option<Self::ActionRef>;
 
-    /// Add a new exit
-    fn add_dynamic(&mut self) -> Self::ActionRef;
+    /// Insert a new exit
+    fn insert_dynamic(&mut self) -> Option<Self::ActionRef>;
 
-    /// Add a control edge between to basic blocks
-    fn add_control_edge(&mut self, source: Self::ActionRef, target: Self::ActionRef, index: u8);
+    /// Insert a control edge between to basic blocks
+    fn insert_control_edge(&mut self, source: Self::ActionRef, target: Self::ActionRef, index: u8) -> Option<Self::CFEdgeRef>;
 
-    fn remove_control_edge(&mut self, source: Self::CFEdgeRef);
-
-    /// Will remove a block and all its associated data from the graph
+    /// Remove a block and all its associated data from the graph
     fn remove_block(&mut self, node: Self::ActionRef);
+
+    /// Remove a control edge from the graph
+    fn remove_control_edge(&mut self, source: Self::CFEdgeRef);
 }

--- a/src/middle/ssa/cfg_traits.rs
+++ b/src/middle/ssa/cfg_traits.rs
@@ -45,8 +45,8 @@ use super::graph_traits::{Graph, ConditionInfo};
 
 /// Provides __accessors__ to the underlying storage
 pub trait CFG: Graph {
-	type ActionRef: Eq + Hash + Clone + Copy + Debug;
-	type CFEdgeRef: Eq + Hash + Clone + Copy + Debug;
+    type ActionRef: Eq + Hash + Clone + Copy + Debug;
+    type CFEdgeRef: Eq + Hash + Clone + Copy + Debug;
 
     /// Check whether the node is a basic block.
     fn is_block(&self, action: Self::ActionRef) -> bool;
@@ -103,7 +103,7 @@ pub trait CFG: Graph {
 
 /// Provides __mutators__ to the underlying storage
 pub trait CFGMod: CFG {
-	type BBInfo;
+    type BBInfo;
 
     /// Mark the start node for the SSA graph
     fn set_entry_node(&mut self, start: Self::ActionRef);

--- a/src/middle/ssa/cfg_traits.rs
+++ b/src/middle/ssa/cfg_traits.rs
@@ -7,9 +7,7 @@
 
 //! Defines the traits to be implemented by the Control Flow Graph (CFG).
 //!
-//! These traits act as a way to abstract the actual storage
-//! mechanism of the CFG (and SSA).
-//! Any struct that implement these traits can be used with other methods.
+//! These traits extend upon the ones provided in `graph_traits`
 //!
 //! # Design
 //!
@@ -43,9 +41,10 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use middle::ir::MAddress;
+use super::graph_traits::Graph;
 
 /// Provides __accessors__ to the underlying storage
-pub trait CFG {
+pub trait CFG: Graph {
 	type ActionRef: Eq + Hash + Clone + Copy + Debug;
 	type CFEdgeRef: Eq + Hash + Clone + Copy + Debug;
 
@@ -53,7 +52,7 @@ pub trait CFG {
     fn blocks(&self) -> Vec<Self::ActionRef>;
 
     /// Reference to entry block of the CFG
-    fn start_node(&self) -> Self::ActionRef;
+    fn entry_node(&self) -> Self::ActionRef;
 
     /// Reference to exit block of the CFG
     fn exit_node(&self) -> Self::ActionRef;
@@ -80,18 +79,11 @@ pub trait CFG {
     /// Reference to all the incoming edges to a block
     fn incoming_edges(&self, i: &Self::ActionRef) -> Vec<(Self::CFEdgeRef, u8)>;
 
-    /// Returns (source_block, target_block) for an edge
-    fn info(&self, i: &Self::CFEdgeRef) -> (Self::ActionRef, Self::ActionRef);
-
     /// Reference to the source block for the edge
-    fn source_of(&self, i: &Self::CFEdgeRef) -> Self::ActionRef {
-        self.info(i).0
-    }
+    fn source_of(&self, i: &Self::CFEdgeRef) -> Self::ActionRef;
 
     /// Reference to the target block for the edge
-    fn target_of(&self, i: &Self::CFEdgeRef) -> Self::ActionRef {
-        self.info(i).1
-    }
+    fn target_of(&self, i: &Self::CFEdgeRef) -> Self::ActionRef;
 
     /// Reference to the edge that connects the source to the target.
     fn find_edge(&self, source: &Self::ActionRef, target: &Self::ActionRef) -> Vec<Self::CFEdgeRef>;
@@ -116,7 +108,7 @@ pub trait CFGMod: CFG {
 	type BBInfo;
 
     /// Mark the start node for the SSA graph
-    fn mark_start_node(&mut self, start: &Self::ActionRef);
+    fn mark_entry_node(&mut self, start: &Self::ActionRef);
 
     /// Mark the exit node for the SSA graph
     fn mark_exit_node(&mut self, exit: &Self::ActionRef);

--- a/src/middle/ssa/graph_traits.rs
+++ b/src/middle/ssa/graph_traits.rs
@@ -33,8 +33,10 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use middle::ir::MAddress;
-use super::ssastorage::{NodeData, EdgeData};
 use petgraph::EdgeDirection;
+
+
+// TODO: Add invalid function for EdgeInfo and ConditionInfo
 
 /// Edge info for avoiding ugly tuples
 #[derive(Clone, Debug)]
@@ -73,6 +75,9 @@ pub trait Graph {
 	type GraphNodeRef: Eq + Hash + Clone + Copy + Debug;
 	type GraphEdgeRef: Eq + Hash + Clone + Copy + Debug;
 
+    type NodeData: Clone + Debug;
+    type EdgeData: Clone + Debug;
+
     /// Return all nodes in the graph.
     fn nodes(&self) -> Vec<Self::GraphNodeRef>;
 
@@ -86,7 +91,7 @@ pub trait Graph {
     fn edge_info(&self, i: Self::GraphEdgeRef) -> Option<EdgeInfo<Self::GraphNodeRef>>;
 
     /// Insert a new node into graph.
-    fn insert_node(&mut self, d: NodeData) -> Option<Self::GraphNodeRef>;
+    fn insert_node(&mut self, d: Self::NodeData) -> Option<Self::GraphNodeRef>;
 
     /// Remove a certain node in the graph.
     fn remove_node(&mut self, exit: Self::GraphNodeRef);
@@ -95,13 +100,16 @@ pub trait Graph {
     fn replace_node(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef);
 
     /// Insert a new edge into graph.
-    fn insert_edge(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef, e: EdgeData) -> Option<Self::GraphEdgeRef>; 
+    fn insert_edge(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef, e: Self::EdgeData) -> Option<Self::GraphEdgeRef>; 
 
     /// Update edge information.
-    fn update_edge(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef, e: EdgeData) -> Option<Self::GraphEdgeRef>;
+    fn update_edge(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef, e: Self::EdgeData) -> Option<Self::GraphEdgeRef>;
+
+    /// Reference to the edge that connects the source to the target.
+    fn find_edges_between(&self, source: Self::GraphNodeRef, target: Self::GraphNodeRef) -> Vec<Self::GraphEdgeRef>;
 
     /// Remove edges beteween nodes.
-    fn remove_edge_between(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef); 
+    fn remove_edges_between(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef); 
 
     /// Gather neighborhood nodes.
     fn gather_adjacent(&self, node: Self::GraphNodeRef, direction: EdgeDirection, data: bool) -> Vec<Self::GraphNodeRef>;

--- a/src/middle/ssa/graph_traits.rs
+++ b/src/middle/ssa/graph_traits.rs
@@ -72,8 +72,8 @@ impl<T: Eq + Hash + Clone + Copy + Debug> ConditionInfo<T> {
 
 /// Trait provide basic graph operations.
 pub trait Graph {
-	type GraphNodeRef: Eq + Hash + Clone + Copy + Debug;
-	type GraphEdgeRef: Eq + Hash + Clone + Copy + Debug;
+    type GraphNodeRef: Eq + Hash + Clone + Copy + Debug;
+    type GraphEdgeRef: Eq + Hash + Clone + Copy + Debug;
 
     type NodeData: Clone + Debug;
     type EdgeData: Clone + Debug;

--- a/src/middle/ssa/graph_traits.rs
+++ b/src/middle/ssa/graph_traits.rs
@@ -112,5 +112,5 @@ pub trait Graph {
     fn remove_edges_between(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef); 
 
     /// Gather neighborhood nodes.
-    fn gather_adjacent(&self, node: Self::GraphNodeRef, direction: EdgeDirection, data: bool) -> Vec<Self::GraphNodeRef>;
+    fn gather_adjacences(&self, node: Self::GraphNodeRef, direction: EdgeDirection, data: bool) -> Vec<Self::GraphNodeRef>;
 }

--- a/src/middle/ssa/graph_traits.rs
+++ b/src/middle/ssa/graph_traits.rs
@@ -1,0 +1,108 @@
+// Copyright (c) 2015, The Radare Project. All rights reserved.
+// See the COPYING file at the top-level directory of this distribution.
+// Licensed under the BSD 3-Clause License:
+// <http://opensource.org/licenses/BSD-3-Clause>
+// This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Defines the traits to be implemented by the Control Flow Graph (CFG).
+//!
+//! These traits act as a way to abstract the actual storage
+//! mechanism of the CFG and SSA.
+//! Any struct that implement these traits can be used with other methods.
+//!
+//! # Design
+//!
+//!  * `Graph` - This acts as the base trait upon which the
+//!  whole SSA form is build. The `Graph` trait provides functions to the
+//!  Basic Graph Operation.
+//!
+//!  The above traits are generic over indexes that are used to refer to edges
+//!  and nodes in a graph. 
+//!
+//!  It is important to note that the trait `SSA` and `CFG` require `Graph` to 
+//!  be implemented. 
+//!
+//!  Individual traits and their methods are explained in their respective
+//!  docs.
+//!
+//!  Note: Reference in the docs refers to any type that is used to index
+//!  nodes and edges in the graph and not necessarily __pointers__.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use middle::ir::MAddress;
+use super::ssastorage::{NodeData, EdgeData};
+use petgraph::EdgeDirection;
+
+/// Edge info for avoiding ugly tuples
+#[derive(Clone, Debug)]
+pub struct EdgeInfo<T: Eq + Hash + Clone + Copy + Debug> {
+    pub source: T,
+    pub target: T,
+}
+
+impl<T: Eq + Hash + Clone + Copy + Debug> EdgeInfo<T> {
+    pub fn new(source: T, target: T) -> EdgeInfo<T> {
+        EdgeInfo {
+            source: source,
+            target: target,
+        }
+    }
+}
+
+/// Struct for conditional data, to avoid ugly tuples
+#[derive(Clone, Debug)]
+pub struct ConditionInfo<T: Eq + Hash + Clone + Copy + Debug> {
+    pub true_side: T,
+    pub false_side: T,
+}
+
+impl<T: Eq + Hash + Clone + Copy + Debug> ConditionInfo<T> {
+    pub fn new(true_side: T, false_side: T) -> ConditionInfo<T> {
+        ConditionInfo {
+            true_side: true_side,
+            false_side: false_side,
+        }
+    }
+} 
+
+/// Trait provide basic graph operations.
+pub trait Graph {
+	type GraphNodeRef: Eq + Hash + Clone + Copy + Debug;
+	type GraphEdgeRef: Eq + Hash + Clone + Copy + Debug;
+
+    /// Return all nodes in the graph.
+    fn nodes(&self) -> Vec<Self::GraphNodeRef>;
+
+    /// Return the count of nodes.
+    fn nodes_count(&self) -> usize;
+
+    /// Return the count of edges.
+    fn edges_count(&self) -> usize;
+
+    /// Return edge information.
+    fn edge_info(&self, i: Self::GraphEdgeRef) -> Option<EdgeInfo<Self::GraphNodeRef>>;
+
+    /// Insert a new node into graph.
+    fn insert_node(&mut self, d: NodeData) -> Option<Self::GraphNodeRef>;
+
+    /// Remove a certain node in the graph.
+    fn remove_node(&mut self, exit: Self::GraphNodeRef);
+
+    /// Replace a node by another node.
+    fn replace_node(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef);
+
+    /// Insert a new edge into graph.
+    fn insert_edge(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef, e: EdgeData) -> Option<Self::GraphEdgeRef>; 
+
+    /// Update edge information.
+    fn update_edge(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef, e: EdgeData) -> Option<Self::GraphEdgeRef>;
+
+    /// Remove edges beteween nodes.
+    fn remove_edge_between(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef); 
+
+    /// Gather neighborhood nodes.
+    fn gather_adjacent(&self, node: Self::GraphNodeRef, direction: EdgeDirection, data: bool) -> Vec<Self::GraphNodeRef>;
+}

--- a/src/middle/ssa/memoryssa.rs
+++ b/src/middle/ssa/memoryssa.rs
@@ -392,7 +392,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
         let mem_node = self.g.add_node(data);
         self.associated_nodes.insert(mem_node, *ssa_node);
 
-        let block = self.ssa.block_of(*ssa_node)
+        let block = self.ssa.block_for(*ssa_node)
                             .expect("Value node doesn't belong to any block");
         self.associated_blocks.insert(mem_node, block.clone());
         return mem_node;
@@ -635,7 +635,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
                                                                 .collect();
                         let vuse = self.add_node(&expr, MemOpcode::VUse);
                         for i in set {
-                            let block = self.ssa.block_of(expr)
+                            let block = self.ssa.block_for(expr)
                                                 .expect("Value node doesn't belong to any block");
                             let arg = self.read_variable(i, &block);
                             self.add_use(&vuse, &arg);
@@ -650,7 +650,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
                                                                 .collect();
                         let vdef = self.add_node(&expr, MemOpcode::VDef);
                         for i in set {
-                            let block = self.ssa.block_of(expr)
+                            let block = self.ssa.block_for(expr)
                                                 .expect("Value node doesn't belong to any block");
                             let arg = self.read_variable(i, &block);
                             self.add_use(&vdef, &arg);

--- a/src/middle/ssa/memoryssa.rs
+++ b/src/middle/ssa/memoryssa.rs
@@ -241,18 +241,18 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     // NOTE: It maybe become unnecessary after VSA finish, because VSA could make 
     // may_alias set, rather than in MemorySSA.
     fn init_nodes_type(&mut self) {
-        for node in self.ssa.nodes() {
-            if let Ok(ndata) = self.ssa.get_node_data(&node) {
+        for node in &self.ssa.values() {
+            if let Ok(ndata) = self.ssa.get_node_data(node) {
                 match ndata.nt {
                     NodeType::Op(MOpcode::OpConst(addr)) => {
                         if self.check_global(addr) {
-                            self.global_nodes.insert(node);
+                            self.global_nodes.insert(*node);
                         }
                     }
 
                     NodeType::Comment(reg) => {
                         if self.check_local(reg.clone()) {
-                            self.local_nodes.insert(node);
+                            self.local_nodes.insert(*node);
                         }
                     } 
                     _ => {}
@@ -613,11 +613,11 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     // Main function of MemorySSA, generate Memory SSA using the similar way of 
     // phiplacement.rs
     fn generate(&mut self) {
-        let start_node = self.ssa.start_node();
-        let mem_start_node = self.g.add_node(MemOpcode::MemoryAccess);
-        self.associated_blocks.insert(mem_start_node, start_node);
+        let entry_node = self.ssa.entry_node();
+        let mem_entry_node = self.g.add_node(MemOpcode::MemoryAccess);
+        self.associated_blocks.insert(mem_entry_node, entry_node);
         for i in 0..self.variables.len() {
-            self.write_variable(i, &start_node, &mem_start_node);
+            self.write_variable(i, &entry_node, &mem_entry_node);
         }
         // Init MemorySSA, making MemoryAccess as all variables' define.
 

--- a/src/middle/ssa/memoryssa.rs
+++ b/src/middle/ssa/memoryssa.rs
@@ -613,7 +613,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     // Main function of MemorySSA, generate Memory SSA using the similar way of 
     // phiplacement.rs
     fn generate(&mut self) {
-        let entry_node = self.ssa.entry_node();
+        let entry_node = self.ssa.entry_node().expect("Incomplete CFG graph");
         let mem_entry_node = self.g.add_node(MemOpcode::MemoryAccess);
         self.associated_blocks.insert(mem_entry_node, entry_node);
         for i in 0..self.variables.len() {

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -189,7 +189,7 @@ pub trait SSA: CFG {
     fn sparse_operands_of(&self, i: Self::ValueRef) -> Vec<(u8, Self::ValueRef)>;
 
     /// Get the NodeIndex of the BasicBlock to which node with index 'i' belongs to.
-    fn block_of(&self, i: Self::ValueRef) -> Option<Self::ActionRef>;
+    fn block_for(&self, i: Self::ValueRef) -> Option<Self::ActionRef>;
 
     /// Get the actual NodeData.
     fn node_data(&self, i: Self::ValueRef) -> Result<NodeData, Box<Debug>>;

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -143,7 +143,7 @@ pub struct NodeData {
 // implementations provided
 // the SSA form implements the following traits.
 pub trait SSA: CFG {
-	type ValueRef: Eq + Hash + Clone + Copy + Debug; // We could drop the Copy trait later and insert .clone()
+    type ValueRef: Eq + Hash + Clone + Copy + Debug; // We could drop the Copy trait later and insert .clone()
 
     ///////////////////////////////////////////////////////////////////////////
     //// Node accessors and helpers

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -149,106 +149,65 @@ pub trait SSA: CFG {
     //// Node accessors and helpers
     ///////////////////////////////////////////////////////////////////////////
 
+    /// Check if the node at the given index is a expression or not.
+    fn is_expr(&self, i: Self::ValueRef) -> bool;
+
+    /// Check if the node at the given index is a phi node or not.
+    fn is_phi(&self, i: Self::ValueRef) -> bool;
+
+    /// Returns true if the expression acts as a `Selector` for control flow.
+    fn is_selector(&self, i: Self::ValueRef) -> bool;
+
     /// Get all value nodes in the whole graph.
     fn values(&self) -> Vec<Self::ValueRef>;
 
-    fn get_address(&self, &Self::ValueRef) -> ir::MAddress;
+    /// Get expr/phi node address
+    fn address(&self, Self::ValueRef) -> Option<ir::MAddress>;
 
     /// Get all the NodeIndex of all operations/expressions in the BasicBlock with index 'i'.
-    fn exprs_in(&self, i: &Self::ActionRef) -> Vec<Self::ValueRef>;
-
-    /// Check if the node at the given index is a expression or not.
-    fn is_expr(&self, i: &Self::ValueRef) -> bool;
-
-    /// Check if the node at the given index is a phi node or not.
-    fn is_phi(&self, i: &Self::ValueRef) -> bool;
+    fn exprs_in(&self, i: Self::ActionRef) -> Vec<Self::ValueRef>;
 
     /// Get all phis in the BasicBlock with index 'i'.
-    fn get_phis(&self, i: &Self::ActionRef) -> Vec<Self::ValueRef>;
-
-    /// Get all the uses of the node with index 'i'.
-    fn get_uses(&self, i: &Self::ValueRef) -> Vec<Self::ValueRef>;
-
-    /// Get the NodeIndex of the BasicBlock to which node with index 'i' belongs to.
-    fn get_block(&self, i: &Self::ValueRef) -> Self::ActionRef;
-
-    /// Get the operands for the operation with NodeIndex 'i'.
-    fn get_operands(&self, i: &Self::ValueRef) -> Vec<Self::ValueRef>;
-
-    /// Get the operands for the operation with NodeIndex 'i' as tuples.
-    fn get_sparse_operands(&self, i: &Self::ValueRef) -> Vec<(u8, Self::ValueRef)>;
-
-    /// Get the lhs() of the Operation with NodeIndex 'i'.
-    fn lhs(&self, i: &Self::ValueRef) -> Self::ValueRef {
-        self.get_operands(i)[0]
-    }
-
-    /// Get the rhs() of the Operation with NodeIndex 'i'.
-    fn rhs(&self, i: &Self::ValueRef) -> Self::ValueRef {
-        self.get_operands(i)[1]
-    }
-
-    /// Get the actual NodeData.
-    fn get_node_data(&self, i: &Self::ValueRef) -> Result<NodeData, Box<Debug>>;
-
-    /// Get const information, as a pack of get_node_data on a OpConst node.
-    fn get_const(&self, i: &Self::ValueRef) -> Option<u64>;
-
-    /// Get comment information, as a pack of get_node_data on a Comment data.
-    fn get_comment(&self, i: &Self::ValueRef) -> Option<String>;
-
-    /// Get OpCode information, as a pack of get_node_data on a Comment data.
-    fn get_opcode(&self, i: &Self::ValueRef) -> Option<ir::MOpcode>;
-
-    /// Get information of the register which belongs to the node.
-    fn get_register(&self, _: &Self::ValueRef) -> Vec<String>;
-
-    /// Returns true if the expression acts as a `Selector` for control flow.
-    fn is_selector(&self, i: &Self::ValueRef) -> bool;
-
-    /// Returns the selector for the Block.
-    fn selector_of(&self, i: &Self::ActionRef) -> Option<Self::ValueRef>;
-
-    /// Get the Block for which i acts as a selector.
-    fn selects_for(&self, i: &Self::ValueRef) -> Self::ActionRef;
-
-    /// Get Jump target of a call or an unconditional jump.
-    fn get_target(&self, i: &Self::ValueRef) -> Self::ActionRef;
-
-    /// Get branches of a selector (false_branch, true_branch).
-    fn get_branches(&self, i: &Self::ValueRef) -> (Self::ActionRef, Self::ActionRef);
-
-    /// Helper method that gets only the true branch.
-    fn get_true_branch(&self, i: &Self::ValueRef) -> Self::ActionRef {
-        self.get_branches(i).1
-    }
-
-    /// Helper method that gets only the false branch.
-    fn get_false_branch(&self, i: &Self::ValueRef) -> Self::ActionRef {
-        self.get_branches(i).0
-    }
-
-    /// Gets the data dependencies of a value node in any order.
-    /// (See get_operands for ordered return value)
-    fn args_of(&self, node: Self::ValueRef) -> Vec<Self::ValueRef>;
-
-    /// Gets uses dependents of a value node.
-    /// (Equivalent as `SSAMod::get_uses`)
-    fn uses_of(&self, node: Self::ValueRef) -> Vec<Self::ValueRef>;
-
-    /// Get the NodeIndex of the BasicBlock to which node with index 'i' belongs to.
-    /// (Alias for get_block)
-    fn block_of(&self, i: &Self::ValueRef) -> Self::ActionRef {
-        self.get_block(i)
-    }
+    fn phis_in(&self, i: Self::ActionRef) -> Vec<Self::ValueRef>;
 
     /// Get a node that has all register values at the beginning of the specified basic block as args
-    fn registers_at(&self, i: &Self::ActionRef) -> Self::ValueRef;
+    fn registers_in(&self, i: Self::ActionRef) -> Option<Self::ValueRef>;
 
-    fn invalid_value(&self) -> Self::ValueRef;
+    /// Returns the selector for the Block.
+    fn selector_in(&self, i: Self::ActionRef) -> Option<Self::ValueRef>;
 
-    fn to_value(&self, Self::ActionRef) -> Self::ValueRef;
-    fn to_action(&self, Self::ValueRef) -> Self::ActionRef;
+    /// Get the Block for which i acts as a selector.
+    fn selector_for(&self, i: Self::ValueRef) -> Option<Self::ActionRef>;
+
+    /// Get all the uses of the node with index 'i'.
+    fn uses_of(&self, i: Self::ValueRef) -> Vec<Self::ValueRef>;
+
+    /// Get the operands for the operation with NodeIndex 'i'.
+    fn operands_of(&self, i: Self::ValueRef) -> Vec<Self::ValueRef>;
+
+    /// Get the operands for the operation with NodeIndex 'i' as tuples.
+    fn sparse_operands_of(&self, i: Self::ValueRef) -> Vec<(u8, Self::ValueRef)>;
+
+    /// Get the NodeIndex of the BasicBlock to which node with index 'i' belongs to.
+    fn block_of(&self, i: Self::ValueRef) -> Option<Self::ActionRef>;
+
+    /// Get the actual NodeData.
+    fn node_data(&self, i: Self::ValueRef) -> Result<NodeData, Box<Debug>>;
+
+    /// Get const information, as a pack of get_node_data on a OpConst node.
+    fn constant(&self, i: Self::ValueRef) -> Option<u64>;
+
+    /// Get comment information, as a pack of get_node_data on a Comment data.
+    fn comment(&self, i: Self::ValueRef) -> Option<String>;
+
+    /// Get OpCode information, as a pack of get_node_data on a Comment data.
+    fn opcode(&self, i: Self::ValueRef) -> Option<ir::MOpcode>;
+
+    /// Get information of the register which belongs to the node.
+    fn registers(&self, _: Self::ValueRef) -> Vec<String>;
+
+    /// Return invalid value
+    fn invalid_value(&self) -> Option<Self::ValueRef>;
 }
 
 /// Trait for modifying SSA data

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -149,7 +149,11 @@ pub trait SSA: CFG {
     //// Node accessors and helpers
     ///////////////////////////////////////////////////////////////////////////
 
+    /// Get all value nodes in the whole graph.
+    fn values(&self) -> Vec<Self::ValueRef>;
+
     fn get_address(&self, &Self::ValueRef) -> ir::MAddress;
+
     /// Get all the NodeIndex of all operations/expressions in the BasicBlock with index 'i'.
     fn exprs_in(&self, i: &Self::ActionRef) -> Vec<Self::ValueRef>;
 
@@ -245,10 +249,6 @@ pub trait SSA: CFG {
 
     fn to_value(&self, Self::ActionRef) -> Self::ValueRef;
     fn to_action(&self, Self::ValueRef) -> Self::ActionRef;
-
-    fn node_count(&self) -> usize;
-    fn edge_count(&self) -> usize;
-    fn nodes(&self) -> Vec<Self::ValueRef>;
 }
 
 /// Trait for modifying SSA data

--- a/src/middle/ssa/ssadot.rs
+++ b/src/middle/ssa/ssadot.rs
@@ -59,7 +59,7 @@ impl GraphDot for SSAStorage {
         let invalid_block = self.invalid_action().expect("Invalid Action is not defined");
         match self.g.node_weight(*i) {
             Some(&NodeData::BasicBlock(_)) | Some(&NodeData::DynamicAction) => Some(i.index()),
-            _ => Some(self.block_of(*i).unwrap_or(invalid_block).index()),
+            _ => Some(self.block_for(*i).unwrap_or(invalid_block).index()),
         }
     }
 

--- a/src/middle/ssa/ssadot.rs
+++ b/src/middle/ssa/ssadot.rs
@@ -24,6 +24,7 @@ impl GraphDot for SSAStorage {
 	type NodeIndex = graph::NodeIndex;
 	type EdgeIndex = graph::EdgeIndex;
 
+
     fn configure(&self) -> String {
         "digraph cfg {\nsplines=\"ortho\";\ngraph [fontsize=12 fontname=\"Verdana\" compound=true \
          rankdir=TB;]\n"
@@ -31,7 +32,7 @@ impl GraphDot for SSAStorage {
     }
 
     fn nodes(&self) -> Vec<Self::NodeIndex> {
-        self.valid_nodes()
+        self.g.node_indices().collect()
     }
 
     fn edges(&self) -> Vec<Self::EdgeIndex> {
@@ -186,7 +187,7 @@ impl GraphDot for SSAStorage {
                                          Information<br/>Start Address: {}</font>>",
                                         addr);
                 let mut attrs = Vec::new();
-                if self.start_node() == *i {
+                if self.entry_node() == *i {
                     attrs.push(("rank".to_string(), "min".to_string()));
                 }
 

--- a/src/middle/ssa/ssadot.rs
+++ b/src/middle/ssa/ssadot.rs
@@ -56,9 +56,10 @@ impl GraphDot for SSAStorage {
     }
 
     fn node_cluster(&self, i: &Self::NodeIndex) -> Option<usize> {
+        let invalid_block = self.invalid_action().expect("Invalid Action is not defined");
         match self.g.node_weight(*i) {
             Some(&NodeData::BasicBlock(_)) | Some(&NodeData::DynamicAction) => Some(i.index()),
-            _ => Some(self.get_block(i).index()),
+            _ => Some(self.block_of(*i).unwrap_or(invalid_block).index()),
         }
     }
 

--- a/src/middle/ssa/ssadot.rs
+++ b/src/middle/ssa/ssadot.rs
@@ -187,7 +187,7 @@ impl GraphDot for SSAStorage {
                                          Information<br/>Start Address: {}</font>>",
                                         addr);
                 let mut attrs = Vec::new();
-                if self.entry_node() == *i {
+                if self.entry_node().expect("Incomplete CFG graph") == *i {
                     attrs.push(("rank".to_string(), "min".to_string()));
                 }
 

--- a/src/middle/ssa/ssadot.rs
+++ b/src/middle/ssa/ssadot.rs
@@ -21,8 +21,8 @@ use middle::ssa::cfg_traits::CFG;
 ///////////////////////////////////////////////////////////////////////////////
 
 impl GraphDot for SSAStorage {
-	type NodeIndex = graph::NodeIndex;
-	type EdgeIndex = graph::EdgeIndex;
+    type NodeIndex = graph::NodeIndex;
+    type EdgeIndex = graph::EdgeIndex;
 
 
     fn configure(&self) -> String {

--- a/src/middle/ssa/ssaquote.rs
+++ b/src/middle/ssa/ssaquote.rs
@@ -23,64 +23,64 @@ use middle::ir;
 use super::ssa_traits::{SSA, SSAMod};
 
 struct Variable {
-	name: String,
+    name: String,
 }
 
 type Ref = u16;
 
 enum Pattern {
-	Any,
-	Const(u8),
-	ConstAny,
-	Op0(ir::MOpcode),
-	Op1(ir::MOpcode, Ref),
-	Op2(ir::MOpcode, Ref, Ref),
+    Any,
+    Const(u8),
+    ConstAny,
+    Op0(ir::MOpcode),
+    Op1(ir::MOpcode, Ref),
+    Op2(ir::MOpcode, Ref, Ref),
 }
 
 struct Node {
-	varindex: u8,
-	pattern:  Pattern
+    varindex: u8,
+    pattern:  Pattern
 }
 
 struct SSAQuote {
-	variables: Vec<Variable>,
-	nodes:     Vec<Node>, // contains the quoted trees in postorder
+    variables: Vec<Variable>,
+    nodes:     Vec<Node>, // contains the quoted trees in postorder
 }
 
 trait Binding {
-	fn get_valueref(&self, &SSA, &Variable) -> SSA::ValueRef;
-	fn get_value(&self, &SSA, &Variable) -> u64;
-	fn set_valueref(&mut self, &SSA, &Variable, SSA::ValueRef);
-	fn set_value(&mut self, &SSA, &Variable, u64);
+    fn get_valueref(&self, &SSA, &Variable) -> SSA::ValueRef;
+    fn get_value(&self, &SSA, &Variable) -> u64;
+    fn set_valueref(&mut self, &SSA, &Variable, SSA::ValueRef);
+    fn set_value(&mut self, &SSA, &Variable, u64);
 }
 
 impl SSAQuote {
-	fn insert_into(&self, ssa: &mut SSAMod, block: T::ActionRef, binding: &Binding) {
-		let mut indices = Vec::with_capacity(self.nodes.len());
-		for node in &self.nodes {
-			let i = match node.pattern {
-				Any      => binding.get_valueref(ssa, &self.variables[node.varindex]),
-				Const(n) => ssa.add_const(block, n),
-				ConstAny => ssa.add_const(block, binding.get_value(ssa, &self.variables[node.varindex])),
-				Op0(op)  => ssa.add_op(block, op),
-				Op1(op, op1r) => {
-					let n = ssa.add_op(block, op);
-					ssa.op_use(n, 0, indices[op1r as usize]);
-					n
-				},
-				Op2(op, op1r, op2r) => {
-					let n = ssa.add_op(block, op);
-					ssa.op_use(n, 0, indices[op1r as usize]);
-					ssa.op_use(n, 1, indices[op2r as usize]);
-					n
-				},
-			};
-			indices.push(i);
-		}
-	}
+    fn insert_into(&self, ssa: &mut SSAMod, block: T::ActionRef, binding: &Binding) {
+        let mut indices = Vec::with_capacity(self.nodes.len());
+        for node in &self.nodes {
+            let i = match node.pattern {
+                Any      => binding.get_valueref(ssa, &self.variables[node.varindex]),
+                Const(n) => ssa.add_const(block, n),
+                ConstAny => ssa.add_const(block, binding.get_value(ssa, &self.variables[node.varindex])),
+                Op0(op)  => ssa.add_op(block, op),
+                Op1(op, op1r) => {
+                    let n = ssa.add_op(block, op);
+                    ssa.op_use(n, 0, indices[op1r as usize]);
+                    n
+                },
+                Op2(op, op1r, op2r) => {
+                    let n = ssa.add_op(block, op);
+                    ssa.op_use(n, 0, indices[op1r as usize]);
+                    ssa.op_use(n, 1, indices[op2r as usize]);
+                    n
+                },
+            };
+            indices.push(i);
+        }
+    }
 
-	fn extract_from(&self, ssa: &SSA, binding: &mut Binding) {
-		unimplemented!();
-		//for node in reverse &self.nodes
-	}
+    fn extract_from(&self, ssa: &SSA, binding: &mut Binding) {
+        unimplemented!();
+        //for node in reverse &self.nodes
+    }
 }

--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -258,6 +258,7 @@ impl Graph for SSAStorage {
     fn replace_node(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef) {
         radeco_trace!(logger::Event::SSAReplaceNode(&i, &j));
         // Before replace, we need to copy over the edges.
+        assert!(self.constant(i).is_none());
 
         let mut walk = self.g.neighbors_directed(i, EdgeDirection::Incoming).detach();
         while let Some((edge, othernode)) = walk.next(&self.g) {
@@ -405,8 +406,8 @@ impl Graph for SSAStorage {
 /// ////////////////////////////////////////////////////////////////////////////
 
 impl CFG for SSAStorage {
-	type ActionRef = <SSAStorage as Graph>::GraphNodeRef;
-	type CFEdgeRef = <SSAStorage as Graph>::GraphEdgeRef;
+    type ActionRef = <SSAStorage as Graph>::GraphNodeRef;
+    type CFEdgeRef = <SSAStorage as Graph>::GraphEdgeRef;
 
     fn is_block(&self, node: Self::ActionRef) -> bool {
         if let NodeData::BasicBlock(_) = self.g[node] {
@@ -508,7 +509,7 @@ impl CFG for SSAStorage {
             Some(ConditionInfo::new(true_edge, false_edge))
         }
     }
-    
+
     fn unconditional_edge(&self, i: Self::ActionRef) -> Option<Self::CFEdgeRef> {
         let edges = self.outgoing_edges(i);
         for &(edge, ety) in &edges {
@@ -558,7 +559,7 @@ impl CFG for SSAStorage {
 
 impl CFGMod for SSAStorage {
 
-	type BBInfo = MAddress;
+    type BBInfo = MAddress;
 
     fn set_entry_node(&mut self, si: Self::ActionRef) {
         self.entry_node = si;
@@ -641,7 +642,7 @@ impl CFGMod for SSAStorage {
 /// ////////////////////////////////////////////////////////////////////////////
 
 impl SSA for SSAStorage {
-	type ValueRef = NodeIndex;
+    type ValueRef = NodeIndex;
 
     fn is_expr(&self, exi: Self::ValueRef) -> bool {
         let i = exi;

--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -278,7 +278,7 @@ impl Graph for SSAStorage {
                     _ => {  }
                 }
             } else if let EdgeData::Selector = self.g[edge] {
-                let bb = self.block_of(i)
+                let bb = self.block_for(i)
                              .expect("Value node does'n belong to any block");
                 self.set_selector(j, bb);
             }
@@ -382,7 +382,7 @@ impl Graph for SSAStorage {
         }
     }
 
-    fn gather_adjacent(&self,
+    fn gather_adjacences(&self,
                        node: Self::GraphNodeRef,
                        direction: EdgeDirection,
                        data: bool)
@@ -447,11 +447,11 @@ impl CFG for SSAStorage {
     }
 
     fn preds_of(&self, exi: Self::ActionRef) -> Vec<Self::ActionRef> {
-        self.gather_adjacent(exi, EdgeDirection::Incoming, false)
+        self.gather_adjacences(exi, EdgeDirection::Incoming, false)
     }
 
     fn succs_of(&self, exi: Self::ActionRef) -> Vec<Self::ActionRef> {
-        self.gather_adjacent(exi, EdgeDirection::Outgoing, false)
+        self.gather_adjacences(exi, EdgeDirection::Outgoing, false)
     }
 
     fn unconditional_block(&self, i: Self::ActionRef) -> Option<Self::ActionRef> {
@@ -754,7 +754,7 @@ impl SSA for SSAStorage {
     }
 
     fn uses_of(&self, node: Self::ValueRef) -> Vec<Self::ValueRef> {
-        self.gather_adjacent(node, EdgeDirection::Incoming, true)
+        self.gather_adjacences(node, EdgeDirection::Incoming, true)
     }
 
     fn operands_of(&self, exi: Self::ValueRef) -> Vec<Self::ValueRef> {
@@ -775,7 +775,7 @@ impl SSA for SSAStorage {
         args
     }
 
-    fn block_of(&self, i: Self::ValueRef) -> Option<Self::ActionRef> {
+    fn block_for(&self, i: Self::ValueRef) -> Option<Self::ActionRef> {
         let mut walk = self.g.neighbors_directed(i, EdgeDirection::Outgoing).detach();
         while let Some((edge, othernode)) = walk.next(&self.g) {
             if let EdgeData::ContainedInBB(_) = self.g[edge] {
@@ -836,7 +836,7 @@ impl SSA for SSAStorage {
         // Self-loop in RadecoIL is not welcomed ;D
         // Thus, Comment Node in entry_node will not have a RegisterInfo edge pointing to itself.
         if let Some(s) = self.comment(i) {
-            if self.block_of(i) == self.entry_node() {
+            if self.block_for(i) == self.entry_node() {
                 regs.push(s);
             }
         } 

--- a/src/middle/ssa/verifier.rs
+++ b/src/middle/ssa/verifier.rs
@@ -14,6 +14,7 @@ use std::fmt::Debug;
 use std::collections::{HashMap, VecDeque};
 use petgraph::graph::NodeIndex;
 
+use super::graph_traits::Graph;
 use super::cfg_traits::CFG;
 use super::ssa_traits::{SSA, ValueType};
 use super::ssa_traits::NodeData as TNodeData;
@@ -78,7 +79,7 @@ macro_rules! check {
 
 impl Verify for SSAStorage {
     fn verify_block(&self, block: &NodeIndex) -> VResult<Self> {
-        let _ = self.node_count();
+        let _ = self.nodes_count();
 
         let edges = self.edges_of(block);
 

--- a/src/middle/ssa/verifier.rs
+++ b/src/middle/ssa/verifier.rs
@@ -72,9 +72,9 @@ pub trait Verify: SSA + Sized + Debug {
 //}
 
 macro_rules! check {
-	($cond: expr, $ssaerr: expr) => (
-		if !$cond { return Err($ssaerr) }
-	);
+    ($cond: expr, $ssaerr: expr) => (
+        if !$cond { return Err($ssaerr) }
+    );
 }
 
 impl Verify for SSAStorage {
@@ -111,10 +111,10 @@ impl Verify for SSAStorage {
                     //  * The jump targets must not be the same block.
                     check!(edges.len() == 2,
                            SSAErr::WrongNumEdges(*block, 2, edges.len()));
-                    let branchs = self.conditional_edges(*block).expect("No conditonal edges is found");
+                    let branches = self.conditional_edges(*block).expect("No conditonal edges is found");
                     let other_edge = match edge.1 {
-                        0 => branchs.true_side,
-                        1 => branchs.false_side,
+                        0 => branches.true_side,
+                        1 => branches.false_side,
                         _ => unreachable!(),
                     };
                     let target_1 = self.edge_info(edge.0).expect("Less-endpoints edge").target;

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -88,11 +88,11 @@ macro_rules! radeco_trace {
 
 #[macro_export]
 macro_rules! radeco_warn {
-	($t: expr) => ({
-		if cfg!(feature = "trace_log") {
-			warn!("{}", $t.to_string());
-		}
-	});
+    ($t: expr) => ({
+        if cfg!(feature = "trace_log") {
+            warn!("{}", $t.to_string());
+        }
+    });
     ($fmt:expr, $($arg:tt)*) => ({
         if cfg!(feature = "trace_log") {
             warn!("{}", format_args!($fmt, $($arg)*));

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -31,7 +31,7 @@ pub mod logger;
 //use middle::ssa::verifier;
 
 //macro_rules! out {
-	//($str: expr, $m: expr) => { if $m { println!($str) } }
+    //($str: expr, $m: expr) => { if $m { println!($str) } }
 //}
 
 //#[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
Associate with #80 .

Because of trying to follow [RFC](https://github.com/rust-lang/rfcs/blob/master/text/0344-conventions-galore.md#gettersetter-apis), I rewrite the code again. Thus, now I haven't finished`SSA` and `SSAMod`. Will do it as soon as possible.

-    [x] Add a basic trait: `Graph`
-    [x] Standardize  `CFG` trait
-    [x] Standardize  `CFGMod` trait
-    [x] Standardize  `SSA` trait
-    [x] Standardize  `SSAMod` trait
-    [x] Modify `SSAExtrait`