### PR TITLE
Fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,28 @@
 sudo: false
 dist: trusty
 language: rust
+# No environment varibles by default
+env:
 addons:
   apt:
     packages:
       - libcurl4-openssl-dev
       - libelf-dev
       - libdw-dev
+      - binutils-dev
+      - cmake
+    sources:
+      - kalakris-cmake
 
 matrix:
   fast_finish: true
+  include:
+    - rust: stable
+      env: COVERALLS=true
   allow_failures:
     - rust: nightly
+    - env: COVERALLS=true
+
 # run builds for all the trains (and more)
 rust:
   - nightly
@@ -24,16 +35,23 @@ os:
   - linux
 before_script:
   - |
-    pip install 'travis-cargo<0.2' --user &&
-    export PATH=$HOME/.local/bin:$PATH
+    if [ "$COVERALLS" = "true" ]; then cargo install cargo-travis &&
+    export PATH=$HOME/.cargo/bin:$PATH; fi
 script:
   - |
-    travis-cargo build &&
-    travis-cargo test &&
-    travis-cargo bench
+    cargo build &&
+    cargo bench;
+    if [ "$COVERALLS" != "true" ];
+      then cargo test;
+    fi
+# The coveralls env runs tests as part of its run
 after_success:
-  - travis-cargo --only stable coveralls --no-sudo --verify
-  - travis-cargo --only stable doc-upload
+  - |
+    if [ "$COVERALLS" = "true" ]; 
+      then travis_wait 30 cargo coveralls --exclude-pattern tests/; 
+    fi
+# Restore automatic doc updating when cargo-travis gets this feature
+#  travis-cargo --only stable doc-upload
 env:
   global:
   - TRAVIS_CARGO_NIGHTLY_FEATURE=""


### PR DESCRIPTION
travis-cargo looks like its been abandoned by the its maintainer and no longer does code coverage: https://github.com/huonw/travis-cargo/issues/58

cargo-travis does the job of doing code coverage, here's an example run: 
https://travis-ci.org/ammaraskar/radeco-lib/builds/288872225
https://coveralls.io/github/ammaraskar/radeco-lib

I made the coverage a seperate build target in travis, and made it failable because it takes a lot longer to run the test suite with coverage, and we don't really care if it builds with coverage or without.