### PR TITLE
Impl type 'ucall'

### DIFF
--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -469,12 +469,24 @@ impl<'a, T> SSAConstruct<'a, T>
             // Handle call separately.
             // NOTE: This is a hack.
             if let Some(ref ty) = op.optype {
-                if ty == "call" {
+                if ty == "call" || ty == "ucall" {
                     let unknown_str = "unknown".to_owned();
-                    let call_operand =
+                    let call_operand = if ty == "call" {
                         self.phiplacer.add_comment(current_address,
                                                    scalar!(0),
-                                                   op.opcode.clone().unwrap_or(unknown_str));
+                                                   op.opcode.clone().unwrap_or(unknown_str))
+                    } else {
+                        //FIXME
+                        let size = {
+                            let esil = op.esil.as_ref().unwrap().clone();
+                            //get_width(esil)
+                            4
+                        };
+                        self.phiplacer.add_comment(current_address,
+                                                   reference!(size),
+                                                   op.opcode.clone().unwrap_or(unknown_str))
+                    };
+
                     let op_call = self.phiplacer
                         .add_op(&MOpcode::OpCall, &mut current_address, scalar!(0));
 

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -471,10 +471,9 @@ impl<'a, T> SSAConstruct<'a, T>
             if let Some(ref ty) = op.optype {
                 if ty == "call" || ty == "ucall" {
                     let unknown_str = "unknown".to_owned();
-                    let call_operand = if ty == "call" {
-                        self.phiplacer.add_comment(current_address,
-                                                   scalar!(0),
-                                                   op.opcode.clone().unwrap_or(unknown_str))
+
+                    let value_type = if ty == "call" {
+                        scalar!(0)
                     } else {
                         //FIXME
                         let size = {
@@ -482,13 +481,16 @@ impl<'a, T> SSAConstruct<'a, T>
                             //get_width(esil)
                             4
                         };
-                        self.phiplacer.add_comment(current_address,
-                                                   reference!(size),
-                                                   op.opcode.clone().unwrap_or(unknown_str))
+                        reference!(size)
                     };
 
+                    let call_operand = 
+                        self.phiplacer.add_comment(current_address,
+                                                   value_type,
+                                                   op.opcode.clone().unwrap_or(unknown_str));
+
                     let op_call = self.phiplacer
-                        .add_op(&MOpcode::OpCall, &mut current_address, scalar!(0));
+                        .add_op(&MOpcode::OpCall, &mut current_address, value_type);
 
 
                     // If `self.assume_cc` is set, then we assume that the callee strictly obeys the

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -475,16 +475,11 @@ impl<'a, T> SSAConstruct<'a, T>
                     let value_type = if ty == "call" {
                         scalar!(0)
                     } else {
-                        //FIXME
-                        let size = {
-                            let esil = op.esil.as_ref().unwrap().clone();
-                            //get_width(esil)
-                            4
-                        };
-                        reference!(size)
+                        //TODO Specify WidthSpec from esil
+                        reference!()
                     };
 
-                    let call_operand = 
+                    let call_operand =
                         self.phiplacer.add_comment(current_address,
                                                    value_type,
                                                    op.opcode.clone().unwrap_or(unknown_str));

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -57,6 +57,9 @@ macro_rules! scalar {
 }
 
 macro_rules! reference {
+    () => {
+        ValueInfo::new($crate::middle::ssa::ssa_traits::ValueType::Reference, ir::WidthSpec::Unknown)
+    };
     ($w:expr) => {
         ValueInfo::new($crate::middle::ssa::ssa_traits::ValueType::Reference, ir::WidthSpec::new_known($w))
     }

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -56,6 +56,12 @@ macro_rules! scalar {
     }
 }
 
+macro_rules! reference {
+    ($w:expr) => {
+        ValueInfo::new($crate::middle::ssa::ssa_traits::ValueType::Reference, ir::WidthSpec::new_known($w))
+    }
+}
+
 impl ValueInfo {
     pub fn new(vty: ValueType, width: ir::WidthSpec) -> ValueInfo {
         ValueInfo {


### PR DESCRIPTION
Related to the issue https://github.com/radare/radeco-lib/issues/34
ucall type is recognized by this PR

The output in ir is following
```
CALL *(#x200fd8)(r15=r15, r14=r14, r13=r13, r12=r12, rbp=%7, rbx=rbx, r11=r11, r10=r10, r9=rdx, r8=%28, rax=rax, rcx=%29, rdx=%9, rsi=%8, rdi=%30, rip=rip, cs=cs, cf=%31, pf=%23, af=af, zf=%13, sf=%15, tf=tf, if=if, df=df, of=%32, rsp=%26, ss=ss, fs_base=fs_base, gs_base=gs_base, ds=ds, es=es, fs=fs, gs=gs)
```

There are two problems,
1. `call reg` (e.g. `call rax`) is not fixed correctly.
2. Value Width is not specified
But I think these other problems. 
Should above problems be fixed on this PR?