### PR TITLE
Add a write_register call to PC during a control flow instruction

### DIFF
--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -209,6 +209,7 @@ impl<'a, T> SSAConstruct<'a, T>
                             // Indirect CF transfer
                             if let Some(ref jump_idx) = rhs {
                                 self.phiplacer.add_indirect_cf(jump_idx, address, UNCOND_EDGE);
+                                self.phiplacer.write_register(address, name, *jump_idx);
                                 // Next instruction should begin in a new block
                                 self.needs_new_block = true;
                             } else {


### PR DESCRIPTION
Currently if we have code like this:

```C
long long dereference(long long* a) {
    return *a;
}
```

The x86 output being:
```asm
subtractOne:
    mov    (%rdi),%rax
    retq
``` 

The esil that gets emmited for the return instruction looks like `rsp,[8],rip,=,8,rsp,+=`, that is, load the return pointer from rsp, add 8 back to the stack for the pop and then load the value into rip.

If we look at the SSA form for this function, it looks like:
```
NodeIndex(78) Op(OpLoad) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Op(OpLoad) } ["rax"]
  arg 0: NodeIndex(36) NodeData { vt: ValueInfo { vty: Scalar, width: Known(0) }, nt: Comment("mem") } ["mem"]
  arg 1: NodeIndex(16) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Comment("rdi") } ["rdi", "rdi"]
NodeIndex(81) Op(OpLoad) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Op(OpLoad) } []
  arg 0: NodeIndex(36) NodeData { vt: ValueInfo { vty: Scalar, width: Known(0) }, nt: Comment("mem") } ["mem"]
  arg 1: NodeIndex(28) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Comment("rsp") } ["rsp"]
NodeIndex(87) Op(OpAdd) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Op(OpAdd) } ["rsp"]
  arg 0: NodeIndex(28) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Comment("rsp") } ["rsp"]
  arg 1: NodeIndex(86) NodeData { vt: ValueInfo { vty: Scalar, width: Known(64) }, nt: Op(OpConst(8)) } []
```

For the dereferencing of argument *a, the OpLoad has an associated register of "rax", but notice that the OpLoad that pops the return instruction pointer isn't associated with "rip".

With this change the SSA looks like:
```
NodeIndex(78) Op(OpLoad) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Op(OpLoad) } ["rax"]
  arg 0: NodeIndex(36) NodeData { vt: ValueInfo { vty: Scalar, width: Known(0) }, nt: Comment("mem") } ["mem"]
  arg 1: NodeIndex(16) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Comment("rdi") } ["rdi", "rdi"]
NodeIndex(81) Op(OpLoad) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Op(OpLoad) } ["rip"]
  arg 0: NodeIndex(36) NodeData { vt: ValueInfo { vty: Scalar, width: Known(0) }, nt: Comment("mem") } ["mem"]
  arg 1: NodeIndex(28) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Comment("rsp") } ["rsp"]
NodeIndex(87) Op(OpAdd) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Op(OpAdd) } ["rsp"]
  arg 0: NodeIndex(28) NodeData { vt: ValueInfo { vty: Unresolved, width: Known(64) }, nt: Comment("rsp") } ["rsp"]
  arg 1: NodeIndex(86) NodeData { vt: ValueInfo { vty: Scalar, width: Known(64) }, nt: Op(OpConst(8)) } []
```