### PR TITLE
WIP Update/minidec

### DIFF
--- a/minidec/cli.rs
+++ b/minidec/cli.rs
@@ -21,9 +21,9 @@ pub fn init_for_args(usage: &str) -> Vec<String> {
 // In case of full match, a message will be displayed to the user
 // In case of partial matching, a list of unmatched items will be shown
 // If no matching occurred, all the available results will be displayed
-pub fn print_match_summary(matched_funcs: &Vec<(u64, &String)>,
-                           requested_funcs: &Vec<String>,
-                           all_func_names: &Vec<&String>) {
+pub fn print_match_summary(matched_funcs: &Vec<(u64, &str)>,
+                           requested_funcs: &Vec<&str>,
+                           all_func_names: &Vec<&str>) {
 
     // Tells the user if a partial match happened
     if requested_funcs.len() == matched_funcs.len() {
@@ -34,8 +34,8 @@ pub fn print_match_summary(matched_funcs: &Vec<(u64, &String)>,
     if requested_funcs.len() > matched_funcs.len() && matched_funcs.len() > 0 {
         println!("Some requested functions weren't found: ");
 
-        let func_names: HashSet<&String> = matched_funcs.iter().map(|rfn| rfn.1).collect();
-        let requested_funcs: HashSet<&String> = requested_funcs.iter().collect();
+        let func_names: HashSet<&str> = matched_funcs.into_iter().map(|rfn| rfn.1).collect();
+        let requested_funcs: HashSet<&str> = requested_funcs.into_iter().map(|x| *x).collect();
 
         let not_found = requested_funcs.difference(&func_names);
 

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -21,7 +21,7 @@ use radeco_lib::analysis::sccp;
 //use radeco_lib::analysis::valueset::analyzer_wysinwyx::FnAnalyzer;
 //use radeco_lib::analysis::valueset::mem_structs::{A_Loc,AbstractAddress};
 use radeco_lib::analysis::interproc::fixcall::CallFixer;
-use radeco_lib::frontend::containers::RadecoModule;
+use radeco_lib::frontend::radeco_containers::{RadecoProject, RadecoModule};
 use radeco_lib::middle::{dce, dot};
 use radeco_lib::middle::ir_writer::IRWriter;
 use radeco_lib::middle::ssa::memoryssa::MemorySSA;
@@ -41,173 +41,186 @@ fn main() {
 
     let requested_functions = cli::init_for_args(USAGE);
 
-    let mut dir;
-    let mut r2 = R2::new::<String>(env::args().nth(env::args().len() - 1))
-        .expect("Unable to open r2");
-    r2.init();
-    let mut rmod = {
-        let bin_info = r2.bin_info().expect("Failed to load bin_info");
-        let fname = bin_info.core.unwrap().file.unwrap();
-        let fname = Path::new(&fname).file_stem().unwrap();
-        let fname = format!("{}_out", fname.to_str().unwrap());
-        dir = PathBuf::from(".");
-        dir.push(&fname);
-        fs::create_dir_all(&dir).expect("Failed to create directory");
-        println!("[*] Constructing ...");
-        RadecoModule::from(&mut r2)
-    };
+    //TODO issue119
+    let dir = PathBuf::from(".");
+    // let mut r2 = R2::new::<String>(env::args().nth(env::args().len() - 1))
+    //     .expect("Unable to open r2");
+    // r2.init();
 
-    // Reduce the complexity of rmod.functions to just a vec of (u64,&String)
-    // for easier extraction and matching
-    //
-    // Extract all exsisting function addresses and names
-    let functions = rmod.functions.clone();
-    let mut matched_func_vec: Vec<(u64, &String)> =
-        functions.iter().map(|(fn_addr, rfn)| (fn_addr.clone(), &rfn.name)).collect();
+    //TODO use ProjectLoader
+    let mut rproj = RadecoProject::new();
+    for mut xy in rproj.iter_mut() {
+        let rmod = &mut xy.module;
+        //TODO issue119
+        // let mut rmod = {
+        //     let bin_info = r2.bin_info().expect("Failed to load bin_info");
+        //     let fname = bin_info.core.unwrap().file.unwrap();
+        //     let fname = Path::new(&fname).file_stem().unwrap();
+        //     let fname = format!("{}_out", fname.to_str().unwrap());
+        //     dir = PathBuf::from(".");
+        //     dir.push(&fname);
+        //     fs::create_dir_all(&dir).expect("Failed to create directory");
+        //     println!("[*] Constructing ...");
+        //     RadecoModule::from(&mut r2)
+        // };
 
-    // Analyze preserved for all functions.
-    {
-        println!("[*] Fixing Callee Information");
-        let mut callfixer = CallFixer::new(&mut rmod);
-        callfixer.rounded_analysis();
-    }
+        // Reduce the complexity of rmod.functions to just a vec of (u64,&String)
+        // for easier extraction and matching
+        //
+        // Extract all exsisting function addresses and names
+        // TODO issue119
+        // let functions = rmod.iter().collect::<Vec<_>>.clone();
+   
 
-    // Filter the data if the user provided some args to be matched upon
-    if requested_functions.len() != 0 {
-        let all_func_names: Vec<(&String)> =
-            matched_func_vec.iter().map(|&(_, name)| name).collect();
-
-        matched_func_vec = filter_with(&matched_func_vec, &requested_functions);
-        cli::print_match_summary(&matched_func_vec, &requested_functions, &all_func_names);
-    }
-
-
-    // Main file to contain IRs of all rfns
-    let mut ffm;
-    {
-        let mut fname = PathBuf::from(&dir);
-        fname.push("main");
-        ffm = File::create(&fname).expect("Unable to create file");
-    }
-
-    for (addr, _) in matched_func_vec {
-
-        let ref mut rfn = rmod.functions.get_mut(&addr).unwrap();
-
-        println!("[+] Analyzing: {} @ {:#x}", rfn.name, addr);
-        {
-            println!("  [*] Eliminating Dead Code");
-            dce::collect(&mut rfn.ssa);
-        }
-        let mut ssa = {
-            // Constant Propagation (sccp)
-            println!("  [*] Propagating Constants");
-            let mut analyzer = sccp::Analyzer::new(&mut rfn.ssa);
-            analyzer.analyze();
-            analyzer.emit_ssa()
+        // Filter the data if the user provided some args to be matched upon
+        let matched_func_addrs = if requested_functions.len() != 0 {
+ 
+            //XXX Impl in more efficient way
+            let mut matched_func_vec: Vec<(u64, &str)> =
+                rmod.iter().map(|_f| {
+                    let f = _f.function.1;
+                    (f.offset.clone(), &*f.name)
+                }).collect();
+                // rmod.iter().map(|(fn_addr, rfn)| (fn_addr.clone(), &rfn.name)).collect();
+            //TODO issue119
+            // Analyze preserved for all functions.
+            // {
+            //     println!("[*] Fixing Callee Information");
+            //     let mut callfixer = CallFixer::new(rmod, None, None);
+            //     callfixer.rounded_analysis();
+            // }
+            let all_func_names: Vec<(&str)> =
+                matched_func_vec.iter().map(|&(_, name)| name).collect();
+            matched_func_vec = filter_with(&matched_func_vec,
+                                           &requested_functions.iter().map(|s| &s[..]).collect::<Vec<_>>());
+            cli::print_match_summary(&matched_func_vec,
+                                     &requested_functions.iter().map(|s| &s[..]).collect::<Vec<_>>(),
+                                     &all_func_names);
+            matched_func_vec.into_iter().map(|(addr, _)| addr).collect::<Vec<_>>()
+        } else {
+            Vec::new()
         };
-        {
-            println!("  [*] Eliminating More DeadCode");
-            dce::collect(&mut ssa);
-        }
-        rfn.ssa = ssa;
-        {
-            // Common SubExpression Elimination (cse)
-            println!("  [*] Eliminating Common SubExpressions");
-            let mut cse = CSE::new(&mut rfn.ssa);
-            cse.run();
-        }
-        {
-            // Verify SSA 
-            println!("  [*] Verifying SSA's Validity");
-            match verifier::verify(&rfn.ssa) {
-                Err(e) => {
-                    println!("  [*] Found Error: {}", e);
-                    process::exit(255);
+
+        // Main file to contain IRs of all rfns
+        let mut ffm = {
+            let mut fname = PathBuf::from(&dir);
+            fname.push("main");
+            File::create(&fname).expect("Unable to create file")
+        };
+
+        for addr in matched_func_addrs {
+
+            let ref mut rfn = rmod.functions.get_mut(&addr).unwrap();
+
+            println!("[+] Analyzing: {} @ {:#x}", rfn.name, addr);
+            {
+                println!("  [*] Eliminating Dead Code");
+                dce::collect(rfn.ssa_mut());
+            }
+            let mut ssa = {
+                // Constant Propagation (sccp)
+                println!("  [*] Propagating Constants");
+                let mut analyzer = sccp::Analyzer::new(rfn.ssa_mut());
+                analyzer.analyze();
+                analyzer.emit_ssa()
+            };
+            {
+                println!("  [*] Eliminating More DeadCode");
+                dce::collect(&mut ssa);
+            }
+            {
+                // Common SubExpression Elimination (cse)
+                println!("  [*] Eliminating Common SubExpressions");
+                let mut cse = CSE::new(rfn.ssa_mut());
+                cse.run();
+            }
+            {
+                // Verify SSA 
+                println!("  [*] Verifying SSA's Validity");
+                match verifier::verify(rfn.ssa()) {
+                    Err(e) => {
+                        println!("  [*] Found Error: {}", e);
+                        process::exit(255);
+                    }
+                    Ok(_) => {  }
                 }
-                Ok(_) => {  }
+            }
+            //TODO issue119
+            {
+                // Building memory SSA.
+                let _memory_ssa = {
+                    // Generate MemorySSA
+                    println!("  [*] Generating Memory SSA");
+                    let mut mssa = MemorySSA::new(rfn.ssa());
+                    mssa.gather_variables(rfn.datarefs(), rfn.locals(),
+                                          rfn.call_sites());
+                    mssa.run();
+                    mssa
+                };
+            }
+            //if false {
+            //    if (!rfn.name.eq("sym.main")) & (!rfn.name.eq("main")) {
+            //        continue;
+            //    }
+            //    println!("  [*] Analyzing Value Sets");
+            //    let fn_analyzer = FnAnalyzer::from((*rfn).clone());
+            //    let a_store_fn = fn_analyzer.analyze_rfn();
+            //    for (a_loc, strided_interval) in a_store_fn.store {
+            //        if let A_Loc{addr: AbstractAddress::Node{..}, ..} = a_loc {
+            //            continue;
+            //        };
+            //        println!("{}", a_loc);
+            //        println!("Strided Interval: {}", strided_interval);
+            //    };
+            //}
+            
+            //{
+                //// Expreimental reference marking pass
+                //println!("  [*] Unstable> Marking References");
+                //let mut rmark = mark_refs::ReferenceMarker { };
+                //rmark.resolve_refs(&mut rfn.ssa);
+            //}
+
+            let mut fname = PathBuf::from(&dir);
+            fname.push(rfn.name.as_ref());
+
+            {
+                ///////////////////////////
+                // Write out the IR file
+                //////////////////////////
+                println!("  [*] Writing out IR");
+                let mut ff = File::create(&fname).expect("Unable to create file");
+                let mut writer: IRWriter = Default::default();
+                let res = writer.emit_il(Some(rfn.name.to_string()), rfn.ssa());
+                writeln!(ff, "{}", res).expect("Error writing to file");
+                writeln!(ffm, "{}", res).expect("Error writing to file");
+                // Set as a comment in radare2
+                rmod.source.as_mut().unwrap().send(&format!("CC, {} @ {}", fname.to_str().unwrap(), addr));
+            }
+        
+            {
+                ////////////////////////
+                // Generate DOT file
+                ///////////////////////
+                println!("  [*] Generating dot");
+                fname.set_extension("dot");
+                let mut df = File::create(&fname).expect("Unable to create .dot file");
+                let dot = dot::emit_dot(rfn.ssa());
+                writeln!(df, "{}", dot).expect("Error writing to file");
             }
         }
 
-        {
-            // Building memory SSA.
-            let _memory_ssa = {
-                // Generate MemorySSA
-                println!("  [*] Generating Memory SSA");
-                let mut mssa = MemorySSA::new(&rfn.ssa);
-                mssa.gather_variables(&rfn.datarefs, &rfn.locals, 
-                                      &Some(rfn.call_ctx.iter().cloned()
-                                            .map(|x| if x.ssa_ref.is_some() {
-                                                x.ssa_ref.unwrap() } else {
-                                                    NodeIndex::end()
-                                                }).collect()));
-                mssa.run();
-                mssa
-            };
-        }
-
-        //if false {
-        //    if (!rfn.name.eq("sym.main")) & (!rfn.name.eq("main")) {
-        //        continue;
-        //    }
-        //    println!("  [*] Analyzing Value Sets");
-        //    let fn_analyzer = FnAnalyzer::from((*rfn).clone());
-        //    let a_store_fn = fn_analyzer.analyze_rfn();
-        //    for (a_loc, strided_interval) in a_store_fn.store {
-        //        if let A_Loc{addr: AbstractAddress::Node{..}, ..} = a_loc {
-        //            continue;
-        //        };
-        //        println!("{}", a_loc);
-        //        println!("Strided Interval: {}", strided_interval);
-        //    };
-        //}
-        
-        //{
-            //// Expreimental reference marking pass
-            //println!("  [*] Unstable> Marking References");
-            //let mut rmark = mark_refs::ReferenceMarker { };
-            //rmark.resolve_refs(&mut rfn.ssa);
-        //}
-
-        let mut fname = PathBuf::from(&dir);
-        fname.push(&rfn.name);
-
-        {
-            ///////////////////////////
-            // Write out the IR file
-            //////////////////////////
-            println!("  [*] Writing out IR");
-            let mut ff = File::create(&fname).expect("Unable to create file");
-            let mut writer: IRWriter = Default::default();
-            let res = writer.emit_il(Some(rfn.name.clone()), &rfn.ssa);
-            writeln!(ff, "{}", res).expect("Error writing to file");
-            writeln!(ffm, "{}", res).expect("Error writing to file");
-            // Set as a comment in radare2
-            rmod.src.as_mut().unwrap().send(&format!("CC, {} @ {}", fname.to_str().unwrap(), addr));
-        }
-        
-        {
-            ////////////////////////
-            // Generate DOT file
-            ///////////////////////
-            println!("  [*] Generating dot");
-            fname.set_extension("dot");
-            let mut df = File::create(&fname).expect("Unable to create .dot file");
-            let dot = dot::emit_dot(&rfn.ssa);
-            writeln!(df, "{}", dot).expect("Error writing to file");
-        }
+        rmod.source.as_mut().unwrap().send("e scr.color=true");
     }
-
-    rmod.src.as_mut().unwrap().send("e scr.color=true")
 }
 
 // Filters the functions that were in Radeco output AND requested by user
-fn filter_with<'a>(all_funcs: &Vec<(u64, &'a String)>,
-                   requested: &Vec<String>)
-                   -> Vec<(u64, &'a String)> {
+fn filter_with<'a>(all_funcs: &Vec<(u64, &'a str)>,
+                   requested: &Vec<&'a str>)
+                   -> Vec<(u64, &'a str)> {
 
     all_funcs.iter()
-        .filter(|&&(_, name)| requested.iter().any(|user_req: &String| *name == *user_req))
+        .filter(|&&(_, name)| requested.iter().any(|user_req| &name == user_req))
         .map(|&(addr, name)| (addr, name))
         .collect()
 }

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -147,15 +147,15 @@ fn main() {
                     Ok(_) => {  }
                 }
             }
-            //TODO issue119
             {
                 // Building memory SSA.
                 let _memory_ssa = {
                     // Generate MemorySSA
                     println!("  [*] Generating Memory SSA");
                     let mut mssa = MemorySSA::new(rfn.ssa());
+                    //TODO issue119
                     mssa.gather_variables(rfn.datarefs(), rfn.locals(),
-                                          rfn.call_sites());
+                                          &rfn.call_sites(&rmod.callgraph));
                     mssa.run();
                     mssa
                 };

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -49,6 +49,7 @@ fn main() {
 
     //TODO use ProjectLoader
     let mut rproj = RadecoProject::new();
+    let regfile = rproj.regfile().clone();
     for mut xy in rproj.iter_mut() {
         let rmod = &mut xy.module;
         //TODO issue119
@@ -71,7 +72,14 @@ fn main() {
         // TODO issue119
         // let functions = rmod.iter().collect::<Vec<_>>.clone();
    
-
+        // Analyze preserved for all functions.
+        {
+            println!("[*] Fixing Callee Information");
+            let bp_name = regfile.get_name_by_alias(&"BP".to_string());
+            let sp_name = regfile.get_name_by_alias(&"SP".to_string());
+            let mut callfixer = CallFixer::new(rmod, bp_name, sp_name);
+            callfixer.rounded_analysis();
+        }
         // Filter the data if the user provided some args to be matched upon
         let matched_func_addrs = if requested_functions.len() != 0 {
  
@@ -82,13 +90,7 @@ fn main() {
                     (f.offset.clone(), &*f.name)
                 }).collect();
                 // rmod.iter().map(|(fn_addr, rfn)| (fn_addr.clone(), &rfn.name)).collect();
-            //TODO issue119
-            // Analyze preserved for all functions.
-            // {
-            //     println!("[*] Fixing Callee Information");
-            //     let mut callfixer = CallFixer::new(rmod, None, None);
-            //     callfixer.rounded_analysis();
-            // }
+
             let all_func_names: Vec<(&str)> =
                 matched_func_vec.iter().map(|&(_, name)| name).collect();
             matched_func_vec = filter_with(&matched_func_vec,

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -21,7 +21,7 @@ use radeco_lib::analysis::sccp;
 //use radeco_lib::analysis::valueset::analyzer_wysinwyx::FnAnalyzer;
 //use radeco_lib::analysis::valueset::mem_structs::{A_Loc,AbstractAddress};
 use radeco_lib::analysis::interproc::fixcall::CallFixer;
-use radeco_lib::frontend::radeco_containers::{RadecoProject, RadecoModule};
+use radeco_lib::frontend::radeco_containers::{ProjectLoader, RadecoProject, RadecoModule};
 use radeco_lib::middle::{dce, dot};
 use radeco_lib::middle::ir_writer::IRWriter;
 use radeco_lib::middle::ssa::memoryssa::MemorySSA;
@@ -41,36 +41,20 @@ fn main() {
 
     let requested_functions = cli::init_for_args(USAGE);
 
-    //TODO issue119
-    let dir = PathBuf::from(".");
-    // let mut r2 = R2::new::<String>(env::args().nth(env::args().len() - 1))
-    //     .expect("Unable to open r2");
-    // r2.init();
-
-    //TODO use ProjectLoader
-    let mut rproj = RadecoProject::new();
+    let proj_name = env::args().nth(env::args().len() -1).unwrap();
+    let mut rproj = {
+        ProjectLoader::new().path(&proj_name).load()
+    };
     let regfile = rproj.regfile().clone();
     for mut xy in rproj.iter_mut() {
         let rmod = &mut xy.module;
-        //TODO issue119
-        // let mut rmod = {
-        //     let bin_info = r2.bin_info().expect("Failed to load bin_info");
-        //     let fname = bin_info.core.unwrap().file.unwrap();
-        //     let fname = Path::new(&fname).file_stem().unwrap();
-        //     let fname = format!("{}_out", fname.to_str().unwrap());
-        //     dir = PathBuf::from(".");
-        //     dir.push(&fname);
-        //     fs::create_dir_all(&dir).expect("Failed to create directory");
-        //     println!("[*] Constructing ...");
-        //     RadecoModule::from(&mut r2)
-        // };
+        let mut dir = PathBuf::from(".");
+        dir.push(format!("{}_out", proj_name));
+        dir.push(format!("{}_out", rmod.name()));
+        fs::create_dir_all(&dir).expect("Failed to create directory");
 
         // Reduce the complexity of rmod.functions to just a vec of (u64,&String)
         // for easier extraction and matching
-        //
-        // Extract all exsisting function addresses and names
-        // TODO issue119
-        // let functions = rmod.iter().collect::<Vec<_>>.clone();
    
         // Analyze preserved for all functions.
         {

--- a/src/analysis/interproc/fixcall.rs
+++ b/src/analysis/interproc/fixcall.rs
@@ -19,9 +19,7 @@ use petgraph::prelude::NodeIndex;
 
 use analysis::cse::ssasort::Sorter;
 use frontend::bindings::{RadecoBindings, RBind, RBindings};
-use frontend::containers::{RadecoFunction, RFunction};
-use frontend::containers::RadecoModule;
-use frontend::containers::CallContext;
+use frontend::radeco_containers::{RadecoFunction, VarBindings, RadecoModule, CallContextInfo};
 use middle::ir::MOpcode;
 use middle::regfile::SubRegisterFile;
 use middle::ssa::cfg_traits::CFG;
@@ -35,28 +33,25 @@ type LIdx<B> = <RadecoBindings<B> as RBindings>::Idx;
 
 
 #[derive(Debug)]
-pub struct CallFixer<'a, 'b: 'a, B>
-    where B: 'b + RBind + Debug + Clone,
-{
-    rmod: &'a mut RadecoModule<'b, RadecoFunction<RadecoBindings<B>>>,
+pub struct CallFixer<'a> {
+    rmod: &'a mut RadecoModule,
     sp_offsets: HashMap<u64, Option<i64>>,
     sp_name: Option<String>,
     bp_name: Option<String>,
 }
 
-impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
-    where B: 'b + RBind + Debug + Clone,
-{
-    pub fn new(rmod: &'a mut RadecoModule<'b, RadecoFunction<RadecoBindings<B>>>) 
-        -> CallFixer<'a, 'b, B> {
-            let regfile = rmod.regfile.clone()
-                .unwrap_or_else(|| {
-                    radeco_err!("regfile is None");
-                    SubRegisterFile::default()
-                });
+impl<'a> CallFixer<'a> {
+    //TODO sp_name, bp_name issue119
+    pub fn new(rmod: &'a mut RadecoModule, bp_name: Option<String>, sp_name: Option<String>) -> CallFixer<'a> {
+    // pub fn new(rmod: &'a mut RadecoModule) -> CallFixer<'a> {
+            // let regfile = rmod.regfile.clone()
+            //     .unwrap_or_else(|| {
+            //         radeco_err!("regfile is None");
+            //         SubRegisterFile::default()
+            //     });
             CallFixer {
-                bp_name: regfile.get_name_by_alias(&"BP".to_string()),
-                sp_name: regfile.get_name_by_alias(&"SP".to_string()),
+                bp_name: bp_name,
+                sp_name: sp_name,
                 rmod: rmod,
                 sp_offsets: HashMap::new(),
             }
@@ -110,7 +105,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
 
         let (entry_store, exit_load) = {
             let rfn = self.rmod.functions.get(rfn_addr).unwrap();
-            let ssa = rfn.ssa_ref();
+            let ssa = rfn.ssa();
             let sp_name = self.sp_name.clone().unwrap_or(String::new());
             let bp_name = self.bp_name.clone().unwrap_or(String::new());
             let stack_offset = digstack::rounded_analysis(&ssa, sp_name, bp_name);
@@ -176,7 +171,7 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
         // exit block separately.
         let (entry_store, exit_load) = {
             let rfn = self.rmod.functions.get(rfn_addr).unwrap();
-            let ssa = rfn.ssa_ref();
+            let ssa = rfn.ssa();
 
                 // analysis entry block
             let entry_store = { 
@@ -208,7 +203,8 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
         }
         let call_info: Vec<(LValueRef, Vec<String>)> = {
             let rfn = self.rmod.functions.get(rfn_addr).unwrap();
-            self.preserves_for_call_context(rfn.call_sites())
+            //TODO issue119
+            self.preserves_for_call_context(rfn.call_sites().clone())
         };
         radeco_trace!("CallFixer|Call site: {:?}", call_info);
 
@@ -292,9 +288,9 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
         // Store data into RadecoFunction
         {
             let rfn = self.rmod.functions.get_mut(rfn_addr).unwrap();
-            let mut bindings = rfn.bindings.bindings_mut();
+            let mut bindings = rfn.bindings_mut().into_iter();
             while let Some(bind) = bindings.next() {
-                if preserves.contains(&bind.name()) {
+                if preserves.contains(&*bind.name()) {
                     bind.mark_preserved();
                 }
                 radeco_trace!("CallFixer|Bind: {:?}", bind);
@@ -426,52 +422,62 @@ impl<'a, 'b: 'a, B> CallFixer<'a, 'b, B>
 
     // Get callee's node and its preserved registers
     fn preserves_for_call_context(&self, 
-            call_context: Vec<CallContext<LIdx<B>, LValueRef>>)
+            // call_context: Vec<CallContext<LIdx<B>, LValueRef>>)
+            call_context: Vec<CallContextInfo>)
             -> Vec<(LValueRef, Vec<String>)> 
     {
         let mut result: Vec<(LValueRef, Vec<String>)> = Vec::new(); 
 
         for con in call_context {
             // We only analyze the call context which have ssa node.
-            if con.ssa_ref.is_none() {
-                continue;
-            }
+            // TODO issue119
+            // if con.ssa_ref.is_none() {
+            //     continue;
+            // }
+            
+            // TODO issue119
             // If callee is not certain
-            if con.callee.is_none() {
-                let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
-                    radeco_err!("con.ssa_ref == None");
-                    NodeIndex::end()
-                });
-                let sp_name = vec![self.sp_name.clone().unwrap_or(String::new())];
-                result.push((ssa_ref, sp_name));
-                continue;
-            }
+            // if con.callee.is_none() {
+            //     let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
+            //         radeco_err!("con.ssa_ref == None");
+            //         NodeIndex::end()
+            //     });
+            //     let sp_name = vec![self.sp_name.clone().unwrap_or(String::new())];
+            //     result.push((ssa_ref, sp_name));
+            //     continue;
+            // }
             let mut preserves: Vec<String> = Vec::new();
-            let rfn_opt = self.rmod.functions.get(con.callee.as_ref().unwrap_or_else(|| {
-                radeco_err!("Callee not found");
-                &0
-            }));
+            //TODO issue119
+            let rfn_opt: Option<RadecoFunction> = None;
+            // let rfn_opt = self.rmod.functions.get(con.callee.as_ref().unwrap_or_else(|| {
+            //     radeco_err!("Callee not found");
+            //     &0
+            // }));
             if let Some(rfn) = rfn_opt {
                 // Callee is man made function
-                let mut bindings = rfn.bindings.bindings();
+                let mut bindings = rfn.bindings().into_iter();
                 while let Some(bind) = bindings.next() {
                     if bind.is_preserved() {
-                        preserves.push(bind.name());
+                        preserves.push(bind.name().to_string());
                     }
                 }
-                let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
-                    radeco_err!("con.ssa_ref == None");
-                    NodeIndex::end()
-                });
-                result.push((ssa_ref, preserves));
+                //TODO issue119
+                unimplemented!();
+                // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
+                //     radeco_err!("con.ssa_ref == None");
+                //     NodeIndex::end()
+                // });
+                // result.push((ssa_ref, preserves));
             } else {
                 // Callee is library function
-                let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
-                    radeco_err!("con.ssa_ref == None");
-                    NodeIndex::end()
-                });
-                let bp_name = vec![self.sp_name.clone().unwrap_or(String::new())];
-                result.push((ssa_ref, bp_name));
+                //TODO issue119
+                unimplemented!()
+                // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
+                //     radeco_err!("con.ssa_ref == None");
+                //     NodeIndex::end()
+                // });
+                // let bp_name = vec![self.sp_name.clone().unwrap_or(String::new())];
+                // result.push((ssa_ref, bp_name));
 
             }
         }

--- a/src/analysis/interproc/fixcall.rs
+++ b/src/analysis/interproc/fixcall.rs
@@ -517,20 +517,19 @@ impl<'a> CallFixer<'a> {
 mod test {
     use super::*;
     use frontend::source::FileSource;
-    use frontend::containers::RadecoModule;
+    use frontend::radeco_containers::RadecoModule;
 
     #[test]
     #[ignore]
     fn analysis_test() {
-        let mut fsource = FileSource::open(Some("./test_files/ct1_sccp_ex/ct1_sccp_ex"));
-        let mut rmod = RadecoModule::from(&mut fsource);
+        let mut rmod = RadecoModule::new("./test_files/ct1_sccp_ex/ct1_sccp_ex".to_string());
         let functions = rmod.functions.clone();
         let matched_func_vec: Vec<u64> =
             functions.iter().map(|(fn_addr, _)| fn_addr.clone()).collect();
 
         // Analyze preserved for all functions.
         {
-            let mut callfixer = CallFixer::new(&mut rmod);
+            let mut callfixer = CallFixer::new(&mut rmod, None, None);
             for func in &matched_func_vec {
                 callfixer.analysis(&func);
             }    
@@ -540,15 +539,14 @@ mod test {
     #[test]
     #[ignore]
     fn fix_test() {
-        let mut fsource = FileSource::open(Some("./test_files/ct1_sccp_ex/ct1_sccp_ex"));
-        let mut rmod = RadecoModule::from(&mut fsource);
+        let mut rmod = RadecoModule::new("./test_files/ct1_sccp_ex/ct1_sccp_ex".to_string());
         let functions = rmod.functions.clone();
         let matched_func_vec: Vec<u64> =
             functions.iter().map(|(fn_addr, _)| fn_addr.clone()).collect();
 
         // Analyze preserved for all functions.
         {
-            let mut callfixer = CallFixer::new(&mut rmod);
+            let mut callfixer = CallFixer::new(&mut rmod, None, None);
             for func in &matched_func_vec {
                 callfixer.analysis(&func);
             }    
@@ -561,15 +559,14 @@ mod test {
     #[test]
     #[ignore]
     fn reanalysis_test() {
-        let mut fsource = FileSource::open(Some("./test_files/ct1_sccp_ex/ct1_sccp_ex"));
-        let mut rmod = RadecoModule::from(&mut fsource);
+        let mut rmod = RadecoModule::new("./test_files/ct1_sccp_ex/ct1_sccp_ex".to_string());
         let functions = rmod.functions.clone();
         let matched_func_vec: Vec<u64> =
             functions.iter().map(|(fn_addr, _)| fn_addr.clone()).collect();
 
         // Analyze preserved for all functions.
         {
-            let mut callfixer = CallFixer::new(&mut rmod);
+            let mut callfixer = CallFixer::new(&mut rmod, None, None);
             for func in &matched_func_vec {
                 callfixer.analysis(&func);
             }    
@@ -585,12 +582,11 @@ mod test {
     #[test]
     #[ignore]
     fn rounded_analysis_test() {
-        let mut fsource = FileSource::open(Some("./test_files/ct1_sccp_ex/ct1_sccp_ex"));
-        let mut rmod = RadecoModule::from(&mut fsource);
+        let mut rmod = RadecoModule::new("./test_files/ct1_sccp_ex/ct1_sccp_ex".to_string());
 
         // Analyze preserved for all functions.
         {
-            let mut callfixer = CallFixer::new(&mut rmod);
+            let mut callfixer = CallFixer::new(&mut rmod, None, None);
             callfixer.rounded_analysis();
         }
     }
@@ -598,13 +594,9 @@ mod test {
     #[test]
     #[ignore]
     fn bin_file_rounded_analysis_test() {
-        //let mut r2 = R2::new(Some("./test_files/bin_file")).expect("Failed to open r2");
-        //r2.init();
-        //let mut fsource = FileSource::from(r2);
-        let mut fsource = FileSource::open(Some("./test_files/bin_file/bin_file"));
-        let mut rmod = RadecoModule::from(&mut fsource);
+        let mut rmod = RadecoModule::new("./test_files/ct1_sccp_ex/ct1_sccp_ex".to_string());
         {
-            let mut callfixer = CallFixer::new(&mut rmod);
+            let mut callfixer = CallFixer::new(&mut rmod, None, None);
             callfixer.rounded_analysis();
         }
     } 

--- a/src/analysis/interproc/fixcall.rs
+++ b/src/analysis/interproc/fixcall.rs
@@ -41,7 +41,6 @@ pub struct CallFixer<'a> {
 }
 
 impl<'a> CallFixer<'a> {
-    //TODO sp_name, bp_name issue119
     pub fn new(rmod: &'a mut RadecoModule, bp_name: Option<String>, sp_name: Option<String>) -> CallFixer<'a> {
             CallFixer {
                 bp_name: bp_name,
@@ -197,7 +196,6 @@ impl<'a> CallFixer<'a> {
         }
         let call_info: Vec<(LValueRef, Vec<String>)> = {
             let rfn = self.rmod.functions.get(rfn_addr).unwrap();
-            //TODO issue119
             self.preserves_for_call_context(rfn.call_sites().clone())
         };
         radeco_trace!("CallFixer|Call site: {:?}", call_info);
@@ -429,50 +427,34 @@ impl<'a> CallFixer<'a> {
             //     continue;
             // }
             
-            // TODO issue119
-            // If callee is not certain
-            // if con.callee.is_none() {
-            //     let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
-            //         radeco_err!("con.ssa_ref == None");
-            //         NodeIndex::end()
-            //     });
-            //     let sp_name = vec![self.sp_name.clone().unwrap_or(String::new())];
-            //     result.push((ssa_ref, sp_name));
-            //     continue;
-            // }
-            let mut preserves: Vec<String> = Vec::new();
-            //TODO issue119
-            let rfn_opt: Option<RadecoFunction> = None;
-            // let rfn_opt = self.rmod.functions.get(con.callee.as_ref().unwrap_or_else(|| {
-            //     radeco_err!("Callee not found");
-            //     &0
-            // }));
-            if let Some(rfn) = rfn_opt {
-                // Callee is man made function
-                let mut bindings = rfn.bindings().into_iter();
-                while let Some(bind) = bindings.next() {
-                    if bind.is_preserved() {
-                        preserves.push(bind.name().to_string());
+            for (caller, callee) in con.map {
+                let mut preserves: Vec<String> = Vec::new();
+                let rfn_opt = self.rmod.functions.get(&con.csite);
+                if let Some(rfn) = rfn_opt {
+                    // Callee is man made function
+                    let mut bindings = rfn.bindings().into_iter();
+                    while let Some(bind) = bindings.next() {
+                        if bind.is_preserved() {
+                            preserves.push(bind.name().to_string());
+                        }
                     }
+                    //TODO issue119
+                    // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
+                    //     radeco_err!("con.ssa_ref == None");
+                    //     NodeIndex::end()
+                    // });
+                    // result.push((ssa_ref, preserves));
+                } else {
+                    // Callee is library function
+                    //TODO issue119
+                    unimplemented!()
+                    // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
+                    //     radeco_err!("con.ssa_ref == None");
+                    //     NodeIndex::end()
+                    // });
+                    // let bp_name = vec![self.sp_name.clone().unwrap_or(String::new())];
+                    // result.push((ssa_ref, bp_name));
                 }
-                //TODO issue119
-                unimplemented!();
-                // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
-                //     radeco_err!("con.ssa_ref == None");
-                //     NodeIndex::end()
-                // });
-                // result.push((ssa_ref, preserves));
-            } else {
-                // Callee is library function
-                //TODO issue119
-                unimplemented!()
-                // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
-                //     radeco_err!("con.ssa_ref == None");
-                //     NodeIndex::end()
-                // });
-                // let bp_name = vec![self.sp_name.clone().unwrap_or(String::new())];
-                // result.push((ssa_ref, bp_name));
-
             }
         }
 

--- a/src/analysis/interproc/fixcall.rs
+++ b/src/analysis/interproc/fixcall.rs
@@ -280,9 +280,8 @@ impl<'a> CallFixer<'a> {
         // Store data into RadecoFunction
         {
             let rfn = self.rmod.functions.get_mut(rfn_addr).unwrap();
-            let mut bindings = rfn.bindings_mut().into_iter();
-            while let Some(bind) = bindings.next() {
-                if preserves.contains(&*bind.name()) {
+            for mut bind in rfn.bindings_mut().into_iter() {
+                if preserves.contains(bind.name()) {
                     bind.mark_preserved();
                 }
                 radeco_trace!("CallFixer|Bind: {:?}", bind);

--- a/src/analysis/interproc/fixcall.rs
+++ b/src/analysis/interproc/fixcall.rs
@@ -43,12 +43,6 @@ pub struct CallFixer<'a> {
 impl<'a> CallFixer<'a> {
     //TODO sp_name, bp_name issue119
     pub fn new(rmod: &'a mut RadecoModule, bp_name: Option<String>, sp_name: Option<String>) -> CallFixer<'a> {
-    // pub fn new(rmod: &'a mut RadecoModule) -> CallFixer<'a> {
-            // let regfile = rmod.regfile.clone()
-            //     .unwrap_or_else(|| {
-            //         radeco_err!("regfile is None");
-            //         SubRegisterFile::default()
-            //     });
             CallFixer {
                 bp_name: bp_name,
                 sp_name: sp_name,

--- a/src/analysis/interproc/fixcall.rs
+++ b/src/analysis/interproc/fixcall.rs
@@ -196,7 +196,7 @@ impl<'a> CallFixer<'a> {
         }
         let call_info: Vec<(LValueRef, Vec<String>)> = {
             let rfn = self.rmod.functions.get(rfn_addr).unwrap();
-            self.preserves_for_call_context(rfn.call_sites().clone())
+            self.preserves_for_call_context(rfn.call_sites(&self.rmod.callgraph).clone())
         };
         radeco_trace!("CallFixer|Call site: {:?}", call_info);
 
@@ -413,47 +413,44 @@ impl<'a> CallFixer<'a> {
 
     // Get callee's node and its preserved registers
     fn preserves_for_call_context(&self, 
-            // call_context: Vec<CallContext<LIdx<B>, LValueRef>>)
-            call_context: Vec<CallContextInfo>)
+            call_context: CallContextInfo)
             -> Vec<(LValueRef, Vec<String>)> 
     {
         let mut result: Vec<(LValueRef, Vec<String>)> = Vec::new(); 
 
-        for con in call_context {
-            // We only analyze the call context which have ssa node.
-            // TODO issue119
-            // if con.ssa_ref.is_none() {
-            //     continue;
-            // }
-            
-            for (caller, callee) in con.map {
-                let mut preserves: Vec<String> = Vec::new();
-                let rfn_opt = self.rmod.functions.get(&con.csite);
-                if let Some(rfn) = rfn_opt {
-                    // Callee is man made function
-                    let mut bindings = rfn.bindings().into_iter();
-                    while let Some(bind) = bindings.next() {
-                        if bind.is_preserved() {
-                            preserves.push(bind.name().to_string());
-                        }
+        // We only analyze the call context which have ssa node.
+        // TODO issue119
+        // if con.ssa_ref.is_none() {
+        //     continue;
+        // }
+
+        for (caller, callee) in call_context.map {
+            let mut preserves: Vec<String> = Vec::new();
+            let rfn_opt = self.rmod.functions.get(&call_context.csite);
+            if let Some(rfn) = rfn_opt {
+                // Callee is man made function
+                let mut bindings = rfn.bindings().into_iter();
+                while let Some(bind) = bindings.next() {
+                    if bind.is_preserved() {
+                        preserves.push(bind.name().to_string());
                     }
-                    //TODO issue119
-                    // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
-                    //     radeco_err!("con.ssa_ref == None");
-                    //     NodeIndex::end()
-                    // });
-                    // result.push((ssa_ref, preserves));
-                } else {
-                    // Callee is library function
-                    //TODO issue119
-                    unimplemented!()
-                    // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
-                    //     radeco_err!("con.ssa_ref == None");
-                    //     NodeIndex::end()
-                    // });
-                    // let bp_name = vec![self.sp_name.clone().unwrap_or(String::new())];
-                    // result.push((ssa_ref, bp_name));
                 }
+                //TODO issue119
+                // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
+                //     radeco_err!("con.ssa_ref == None");
+                //     NodeIndex::end()
+                // });
+                // result.push((ssa_ref, preserves));
+            } else {
+                // Callee is library function
+                //TODO issue119
+                unimplemented!()
+                // let ssa_ref = con.ssa_ref.unwrap_or_else(|| {
+                //     radeco_err!("con.ssa_ref == None");
+                //     NodeIndex::end()
+                // });
+                // let bp_name = vec![self.sp_name.clone().unwrap_or(String::new())];
+                // result.push((ssa_ref, bp_name));
             }
         }
 

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -329,6 +329,17 @@ pub struct ProjectLoader<'a> {
 }
 
 impl<'a> ProjectLoader<'a> {
+
+    pub fn new() -> ProjectLoader<'a> {
+        ProjectLoader {
+            load_libs: false,
+            path: Cow::from(""),
+            load_library_path: None,
+            filter_modules: None,
+            source: None,
+            mloader: None,
+        }
+    }
     // TODO:
     //  - Associate identified bins/libs with their ModuleLoaders
     //  - Implement loading of libraries
@@ -939,6 +950,10 @@ impl RadecoModule {
         let mut rmod = RadecoModule::default();
         rmod.name = Cow::from(path.clone());
         rmod
+    }
+
+    pub fn name(&self) -> &str {
+        &*self.name
     }
 
     pub fn function(&self, offset: u64) -> Option<&RadecoFunction> {

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -49,10 +49,11 @@ use petgraph::graph::{NodeIndex, Graph};
 use petgraph::visit::EdgeRef;
 use r2api::api_trait::R2Api;
 use r2api::structs::{LOpInfo, LRegInfo, LSymbolInfo, LRelocInfo, LImportInfo, LExportInfo,
-                     LSectionInfo, LEntryInfo, LSymbolType};
+                     LSectionInfo, LEntryInfo, LSymbolType, LVarInfo};
 
 use r2pipe::r2::R2;
 use rayon::prelude::*;
+use std::fmt;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::cmp::Ordering;
@@ -179,6 +180,12 @@ pub struct RadecoModule {
     pub source: Option<Rc<Source>>,
 }
 
+impl fmt::Debug for RadecoModule {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        unimplemented!()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum FunctionType {
     /// Function defined in the current binary
@@ -264,6 +271,21 @@ impl VarBinding {
 
     pub fn btype_mut(&mut self) -> &mut BindingType {
         &mut self.btype
+    }
+
+    //XXX issue119
+    pub fn name(&self) -> &str {
+        &*self.name
+    }
+
+    //TODO issue119
+    pub fn is_preserved(&self) -> bool {
+        unimplemented!()
+    }
+
+    //TODO issue119
+    pub fn mark_preserved(&self) {
+        unimplemented!()
     }
 }
 
@@ -991,12 +1013,34 @@ impl RadecoFunction {
     pub fn bindings(&self) -> &VarBindings {
         &self.bindings
     }
+
+    //XXX? issue119
+    pub fn bindings_mut(&mut self) -> &mut VarBindings {
+        &mut self.bindings
+    }
+
+    //TODO
+    pub fn call_sites(&self) -> &Vec<CallContextInfo> {
+        unimplemented!()
+    }
+
+    //XXX issue119
+    pub fn datarefs(&self) -> &Vec<u64> {
+        &self.datarefs
+    }
+
+    //XXX issue119
+    pub fn locals(&self) -> &Vec<LVarInfo> {
+        unimplemented!()
+    }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct CallContextInfo {
     /// NodeIndex mapping from a node in the caller's context to a node in callee's context
+    //TODO issue119
     pub map: Vec<(NodeIndex, NodeIndex)>,
+    // pub map: HashMap<NodeIndex, NodeIndex>,
     /// NodeIndex corresponding to callsite (`OpCall`) in the caller context
     pub csite_node: NodeIndex,
     /// Address of callsite

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -248,6 +248,7 @@ pub struct VarBinding {
     // Index of the register in regfile that represents this varbinding
     pub ridx: Option<u64>,
     pub idx: NodeIndex, // Some arbitrary, serializable data can be added to these fields later.
+    is_preserved: bool,
 }
 
 impl VarBinding {
@@ -258,6 +259,7 @@ impl VarBinding {
             btype: btype,
             idx: idx,
             ridx: ridx,
+            is_preserved: false,
         }
     }
 
@@ -277,36 +279,16 @@ impl VarBinding {
         &*self.name
     }
 
-    //TODO issue119
     pub fn is_preserved(&self) -> bool {
-        unimplemented!()
+        self.is_preserved
     }
 
-    //TODO issue119
-    pub fn mark_preserved(&self) {
-        unimplemented!()
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct VarBindings(Vec<VarBinding>);
-
-impl<'a> IntoIterator for &'a VarBindings {
-    type Item = &'a VarBinding;
-    type IntoIter = VarBindingIter<'a>;
-    fn into_iter(self) -> VarBindingIter<'a> {
-        VarBindingIter(self.0.iter())
+    pub fn mark_preserved(&mut self) {
+        self.is_preserved = true;
     }
 }
 
-pub struct VarBindingIter<'a>(slice::Iter<'a, VarBinding>);
-
-impl<'a> Iterator for VarBindingIter<'a> {
-    type Item = &'a VarBinding;
-    fn next(&mut self) -> Option<&'a VarBinding> {
-        self.0.next()
-    }
-}
+pub type VarBindings = Vec<VarBinding>;
 
 #[derive(Debug, Clone, Default)]
 /// Container to store information about identified function.
@@ -667,7 +649,7 @@ impl<'a> ModuleLoader<'a> {
             }
         });
 
-        rfn.bindings = VarBindings(tbindings);
+        rfn.bindings = tbindings;
     }
 
     /// Kick everything off and load module information based on config and defaults

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -1000,8 +1000,9 @@ impl RadecoFunction {
     }
 
     //TODO issue119
-    pub fn call_sites(&self) -> &Vec<CallContextInfo> {
+    pub fn call_sites(&self, call_graph: &CallGraph) -> CallContextInfo {
         unimplemented!()
+        // call_graph.get(self.offset)
     }
 
     pub fn datarefs(&self) -> &Vec<u64> {

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -273,7 +273,6 @@ impl VarBinding {
         &mut self.btype
     }
 
-    //XXX issue119
     pub fn name(&self) -> &str {
         &*self.name
     }
@@ -1014,17 +1013,15 @@ impl RadecoFunction {
         &self.bindings
     }
 
-    //XXX? issue119
     pub fn bindings_mut(&mut self) -> &mut VarBindings {
         &mut self.bindings
     }
 
-    //TODO
+    //TODO issue119
     pub fn call_sites(&self) -> &Vec<CallContextInfo> {
         unimplemented!()
     }
 
-    //XXX issue119
     pub fn datarefs(&self) -> &Vec<u64> {
         &self.datarefs
     }
@@ -1038,9 +1035,7 @@ impl RadecoFunction {
 #[derive(Clone, Debug, Default)]
 pub struct CallContextInfo {
     /// NodeIndex mapping from a node in the caller's context to a node in callee's context
-    //TODO issue119
     pub map: Vec<(NodeIndex, NodeIndex)>,
-    // pub map: HashMap<NodeIndex, NodeIndex>,
     /// NodeIndex corresponding to callsite (`OpCall`) in the caller context
     pub csite_node: NodeIndex,
     /// Address of callsite

--- a/src/frontend/radeco_source.rs
+++ b/src/frontend/radeco_source.rs
@@ -183,7 +183,8 @@ impl<R: R2Api> Source for WrappedR2Api<R> {
     }
 
     fn raw(&self, cmd: String) -> Result<String, SourceErr> {
-        Ok(self.try_borrow_mut()?.raw(cmd))
+        // Ok(self.try_borrow_mut()?.raw(cmd))
+        Ok("".to_string())
     }
 
     fn send(&self, s: &str) -> Result<(), SourceErr> {

--- a/src/middle/ssa/memoryssa.rs
+++ b/src/middle/ssa/memoryssa.rs
@@ -148,7 +148,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     pub fn gather_variables(&mut self,
                         datafers: &Vec<u64>,
                         locals: &Vec<LVarInfo>,
-                        callrefs: &Vec<CallContextInfo>) {
+                        callrefs: &CallContextInfo) {
         radeco_trace!("MemorrySSA|Get datafers: {:?}", datafers);
         // datafers is coming from RadecoFunctoin::datafers
         let mut gvars: Vec<VariableType> 
@@ -168,14 +168,12 @@ impl<'a, I, T> MemorySSA<'a, I, T>
         self.variables.append(&mut lvars);
 
         radeco_trace!("MemorrySSA|Get callrefs: {:?}", callrefs);
-    // callrefs is coming from RadecoFunctoin::call_ctx::ssa_ref
-        //TODO issue119
-        // let mut evars: Vec<VariableType>
-        //     = callrefs.clone()
-        //                 .iter()
-        //                 .map(|x| VariableType::Extra(x.clone()))
-        //                 .collect();
-        // self.variables.append(&mut evars);
+        // callrefs is coming from RadecoFunctoin::call_ctx::ssa_ref
+        let mut evars: Vec<VariableType>
+            = callrefs.map.clone().into_iter()
+                        .map(|(x, _)| VariableType::Extra(x))
+                        .collect();
+        self.variables.append(&mut evars);
 
         radeco_trace!("MemorrySSA|Gather variables: {:?}", self.variables);
 

--- a/src/middle/ssa/memoryssa.rs
+++ b/src/middle/ssa/memoryssa.rs
@@ -22,6 +22,7 @@ use std::marker::PhantomData;
 use petgraph::EdgeDirection;
 use petgraph::stable_graph::StableDiGraph;
 use petgraph::graph::{EdgeIndex,  NodeIndex};
+use frontend::radeco_containers::CallContextInfo;
 
 use r2api::structs::LVarInfo;
 
@@ -145,44 +146,36 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     //      extra: for every call statement generate an extra variable.
     /// Use information from RadecoFunctoin to gather basic variables' information.
     pub fn gather_variables(&mut self,
-                        datafers: &Option<Vec<u64>>,
-                        locals: &Option<Vec<LVarInfo>>,
-                        callrefs: &Option<Vec<NodeIndex>>) {
+                        datafers: &Vec<u64>,
+                        locals: &Vec<LVarInfo>,
+                        callrefs: &Vec<CallContextInfo>) {
         radeco_trace!("MemorrySSA|Get datafers: {:?}", datafers);
         // datafers is coming from RadecoFunctoin::datafers
-        if !datafers.is_none() {
-            let mut gvars: Vec<VariableType> 
-                = datafers.clone()
-                            .unwrap()
-                            .iter()
-                            .map(|x| VariableType::Global(x.clone()))
-                            .collect();
-            self.variables.append(&mut gvars);
-        }
+        let mut gvars: Vec<VariableType> 
+            = datafers.clone()
+            .iter()
+            .map(|x| VariableType::Global(x.clone()))
+            .collect();
+        self.variables.append(&mut gvars);
 
         radeco_trace!("MemorrySSA|Get locals: {:?}", locals);
         // locals is coming from RadecoFunctoin::locals
-        if !locals.is_none() {
-            let mut lvars: Vec<VariableType>
-                = locals.clone()
-                            .unwrap()
-                            .iter()
-                            .map(|x| VariableType::Local(x.clone()))
-                            .collect();
-            self.variables.append(&mut lvars);
-        }
+        let mut lvars: Vec<VariableType>
+            = locals.clone()
+            .iter()
+            .map(|x| VariableType::Local(x.clone()))
+            .collect();
+        self.variables.append(&mut lvars);
 
         radeco_trace!("MemorrySSA|Get callrefs: {:?}", callrefs);
-        // callrefs is coming from RadecoFunctoin::call_ctx::ssa_ref
-        if !callrefs.is_none() {
-            let mut evars: Vec<VariableType>
-                = callrefs.clone()
-                            .unwrap()
-                            .iter()
-                            .map(|x| VariableType::Extra(x.clone()))
-                            .collect();
-            self.variables.append(&mut evars);
-        }
+    // callrefs is coming from RadecoFunctoin::call_ctx::ssa_ref
+        //TODO issue119
+        // let mut evars: Vec<VariableType>
+        //     = callrefs.clone()
+        //                 .iter()
+        //                 .map(|x| VariableType::Extra(x.clone()))
+        //                 .collect();
+        // self.variables.append(&mut evars);
 
         radeco_trace!("MemorrySSA|Gather variables: {:?}", self.variables);
 


### PR DESCRIPTION
Related to the issue #119 
minidec is changed to use latest containers.
But there are still things to do and might be some mistakes especially about the usage of `CallContextInfo` (you can see in `/src/analysis/interproc/fixcall#preserves_for_call_context).

## TODO
Things to do are commented as `TODO issue119` or `XXX issue119`.

And these files(including tests) are still using deprecated containers.
* src/analysis/interproc/fixcall.rs
* src/analysis/interproc/interproc.rs
* src/analysis/interproc/summary.rs
* src/analysis/interproc/transfer.rs
* src/analysis/valueset/analyzer_wysinwyx.rs
* src/backend/lang_c/c_ast_constructor.rs
* tests/bin_file_test.rs