### PR TITLE
Makes pre-processing together in specific files for some tests.

### DIFF
--- a/src/analysis/interproc/digstack.rs
+++ b/src/analysis/interproc/digstack.rs
@@ -302,9 +302,7 @@ mod test {
     use middle::ssa::ssastorage::SSAStorage;
     use middle::dce;
 
-    const REGISTER_PROFILE: &'static str = "test_files/x86_register_profile.json";
-    const BIN_LS_INSTRUCTIONS: &'static str = "test_files/bin_ls_instructions.json";
-    const CT1_INSTRUCTIONS: &'static str = "test_files/ct1_instructions.json";
+    use utils::test_const::{REGISTER_PROFILE, BIN_LS_INSTRUCTIONS, CT1_INSTRUCTIONS};
 
     #[test]
     fn bin_ls_test() {

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -764,8 +764,7 @@ mod test {
     use std::io::prelude::*;
     use super::*;
 
-
-    const REGISTER_PROFILE: &'static str = "test_files/x86_register_profile.json";
+    use utils::test_const::REGISTER_PROFILE;
 
     fn before_test(reg_profile: &mut LRegInfo, instructions: &mut LFunctionInfo, from: &str) {
         // Enable for debugging only.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,6 +11,9 @@
 #[macro_use]
 pub mod logger;
 
+#[cfg(test)]
+pub(crate) mod test_const;
+
 //use std::io::prelude::*;
 //use std::fs;
 //use std::fs::File;

--- a/src/utils/test_const.rs
+++ b/src/utils/test_const.rs
@@ -1,0 +1,4 @@
+pub const REGISTER_PROFILE: &'static str = "test_files/x86_register_profile.json";
+pub const BIN_LS_INSTRUCTIONS: &'static str = "test_files/bin_ls_instructions.json";
+pub const CT1_INSTRUCTIONS: &'static str = "test_files/ct1_instructions.json";
+


### PR DESCRIPTION
I'm writing tests to make accessing `arguments`, and I think that we should make pre-processing together in specific files for some tests.

I implemented constant file's pathes in a file; utils::test_const .

If we think that we'd like to make accessing pre-processing function for some tests, I'll implement the function in this file.