### PR TITLE
Remove duplicated containers

### DIFF
--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -142,7 +142,7 @@ fn main() {
                     println!("  [*] Generating Memory SSA");
                     let mut mssa = MemorySSA::new(rfn.ssa());
                     mssa.gather_variables(rfn.datarefs(), &rfn.locals(),
-                                          &rfn.call_sites(&rmod.callgraph));
+                                          &rfn.call_refs(&rmod.callgraph));
                     mssa.run();
                     mssa
                 };

--- a/minidec/main.rs
+++ b/minidec/main.rs
@@ -136,16 +136,17 @@ fn main() {
                 }
             }
             {
-                // Building memory SSA.
-                let _memory_ssa = {
-                    // Generate MemorySSA
-                    println!("  [*] Generating Memory SSA");
-                    let mut mssa = MemorySSA::new(rfn.ssa());
-                    mssa.gather_variables(rfn.datarefs(), &rfn.locals(),
-                                          &rfn.call_refs(&rmod.callgraph));
-                    mssa.run();
-                    mssa
-                };
+                // TODO
+                // // Building memory SSA.
+                // let _memory_ssa = {
+                //     // Generate MemorySSA
+                //     println!("  [*] Generating Memory SSA");
+                //     let mut mssa = MemorySSA::new(rfn.ssa());
+                //     mssa.gather_variables(rfn.datarefs(), &rfn.locals(),
+                //                           &rfn.call_refs(&rmod.callgraph));
+                //     mssa.run();
+                //     mssa
+                // };
             }
             //if false {
             //    if (!rfn.name.eq("sym.main")) & (!rfn.name.eq("main")) {

--- a/src/analysis/interproc/interproc.rs
+++ b/src/analysis/interproc/interproc.rs
@@ -67,6 +67,7 @@ mod test {
     use super::*;
     use frontend::source::FileSource;
     // use frontend::source::Source;
+    // TODO
     use frontend::containers::*;
     use middle::ir_writer::IRWriter;
     use middle::dce;

--- a/src/analysis/interproc/summary.rs
+++ b/src/analysis/interproc/summary.rs
@@ -107,8 +107,8 @@ impl InterProcAnalysis for CallSummary {
     // values the callee actually modifies.
     fn propagate(&mut self, rmod: &mut RadecoModule, fn_ref: u64) {
         if let Some(rfn) = rmod.functions.get(&fn_ref) {
-            for context in rfn.call_sites(rmod.callgraph()) {
-                let callee = rmod.callgraph().callees(context.csite_node).next()
+            for context in rfn.call_sites(&rmod.callgraph) {
+                let callee = rmod.callgraph.callees(context.csite_node).next()
                     .map(|x| x.0).unwrap_or_else(|| {
                     radeco_err!("Call site cannot have callee as `None`");
                     0

--- a/src/analysis/interproc/summary.rs
+++ b/src/analysis/interproc/summary.rs
@@ -37,8 +37,12 @@ impl<'a, T: RModule<'a>> InterProcAnalysis<'a, T> for CallSummary {
             }
             let rfn = rfn.unwrap();
             {
-                let locals = rfn.locals().iter().map(|x| x.0).collect::<HashSet<_>>();
-                let ssa = rfn.ssa_ref();
+                let locals = rfn.bindings().iter()
+                    .enumerate()
+                    .filter(|&(_, l)| l.btype.is_local())
+                    .map(|(i, _)| i)
+                    .collect::<HashSet<_>>();
+                let ssa = rfn.ssa();
                 // Get register state at the start block.
                 let rs = registers_in_err!(ssa, entry_node_err!(ssa),
                     ssa.invalid_value().unwrap());

--- a/src/analysis/interproc/transfer.rs
+++ b/src/analysis/interproc/transfer.rs
@@ -1,9 +1,9 @@
 //! Defines transfer and propagate traits used for interprocess analysis.
 
-use frontend::containers::RModule;
+use frontend::radeco_containers::{RadecoFunction, RadecoModule};
 
-pub trait InterProcAnalysis<'a, T: RModule<'a>> {
+pub trait InterProcAnalysis {
     fn new() -> Self;
-    fn transfer(&mut self, &mut T, &T::FnRef);
-    fn propagate(&mut self, &mut T, &T::FnRef);
+    fn transfer(&mut self, &mut RadecoModule, u64);
+    fn propagate(&mut self, &mut RadecoModule, u64);
 }

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -315,8 +315,6 @@ pub struct RadecoFunction {
     cgid: NodeIndex,
     /// Variable bindings
     bindings: VarBindings,
-    /// Local Variables of this function
-    locals: Vec<LVarInfo>,
 }
 
 #[derive(Default)]
@@ -813,8 +811,12 @@ impl<'a> ModuleLoader<'a> {
                     if let Some(mut rfn) = rmod.functions.get_mut(&info.offset.unwrap()) {
                         let locals_res = self.source.as_ref()
                             .map(|s| s.locals_of(rfn.offset));
-                        rfn.locals = match locals_res {
-                            Some(Ok(locals)) => locals,
+                        let mut locals = match locals_res {
+                            Some(Ok(locals)) => {
+                                // TODO
+                                radeco_err!("Not implemented yet");
+                                Vec::new()
+                            },
                             Some(Err(e)) => {
                                 radeco_warn!("{:?}", e);
                                 Vec::new()
@@ -824,6 +826,7 @@ impl<'a> ModuleLoader<'a> {
                                 Vec::new()
                             },
                         };
+                        rfn.bindings_mut().append(&mut locals);
                     }
                 }
             }

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -1008,6 +1008,16 @@ impl RadecoModule {
     pub fn sections(&self) -> &Arc<Vec<LSectionInfo>> {
         &self.sections
     }
+
+    pub fn callees_of(&self, rfn: &RadecoFunction) -> Vec<(u64, NodeIndex)> {
+        // TODO More efficient implementation
+        let csite_nodes = rfn.call_sites(&self.callgraph)
+            .into_iter()
+            .map(|c| c.csite_node);
+        csite_nodes.flat_map(|cn| {
+            self.callgraph.callees(cn).collect::<Vec<_>>()
+        }).collect::<Vec<_>>()
+    }
 }
 
 impl RadecoFunction {
@@ -1080,8 +1090,28 @@ impl RadecoFunction {
         &self.datarefs
     }
 
-    pub fn locals(&self) -> &Vec<LVarInfo> {
-        &self.locals
+    pub fn args(&self) -> &VarBindings {
+        unimplemented!()
+    }
+
+    pub fn set_args(&mut self, args: &Vec<usize>) {
+        unimplemented!()
+    }
+
+    pub fn set_modifides(&mut self, locals: &Vec<usize>) {
+        unimplemented!()
+    }
+
+    pub fn set_locals(&mut self, locals: &Vec<usize>) {
+        unimplemented!()
+    }
+
+    pub fn set_returns(&mut self, returns: &Vec<usize>) {
+        for i in returns {
+            if let Some(ref mut var) = self.bindings.iter_mut().nth(*i) {
+                var.btype = BindingType::Return;
+            }
+        }
     }
 }
 

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -1057,24 +1057,15 @@ impl RadecoFunction {
         }).collect::<Vec<_>>()
     }
 
+    pub fn call_refs(&self, call_graph: &CallGraph) -> Vec<NodeIndex> {
+        call_graph.node_indices()
             .filter(|n| {
                 if let Some(node) = call_graph.node_weight(*n) {
-                    *node == self.offset
+                    self.is_addr_in(*node)
                 } else {
                     false
                 }
-            }).collect::<Vec<_>>();
-        if idx.len() != 1 {
-            radeco_err!("NodeIndex: {:?}", idx);
-        };
-        let map = call_graph.callees(idx[0]).into_iter()
-            .map(|i| (idx[0], i.1))
-            .collect::<Vec<_>>();
-        CallContextInfo {
-            map: map,
-            csite_node: idx[0],
-            csite: self.offset,
-        }
+            }).collect::<Vec<_>>()
     }
 
     pub fn datarefs(&self) -> &Vec<u64> {

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -1037,8 +1037,26 @@ impl RadecoFunction {
         &mut self.bindings
     }
 
-    pub fn call_sites(&self, call_graph: &CallGraph) -> CallContextInfo {
-        let idx = call_graph.node_indices()
+    fn is_addr_in(&self, addr: u64) -> bool {
+        self.offset <= addr && addr <= self.offset + self.size
+    }
+
+    pub fn call_sites(&self, call_graph: &CallGraph) -> Vec<CallContextInfo> {
+        let indices = self.call_refs(call_graph);
+        indices.into_iter().filter_map(|idx| {
+            // TODO
+            let map = Vec::new();
+            let csite_opt = call_graph.node_weight(idx);
+            csite_opt.map(|csite| {
+                CallContextInfo {
+                    map: map,
+                    csite_node: idx,
+                    csite: *csite,
+                }
+            })
+        }).collect::<Vec<_>>()
+    }
+
             .filter(|n| {
                 if let Some(node) = call_graph.node_weight(*n) {
                     *node == self.offset

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -1043,17 +1043,22 @@ impl RadecoFunction {
 
     pub fn call_sites(&self, call_graph: &CallGraph) -> Vec<CallContextInfo> {
         let indices = self.call_refs(call_graph);
-        indices.into_iter().filter_map(|idx| {
-            // TODO
-            let map = Vec::new();
-            let csite_opt = call_graph.node_weight(idx);
-            csite_opt.map(|csite| {
-                CallContextInfo {
-                    map: map,
-                    csite_node: idx,
-                    csite: *csite,
-                }
-            })
+        indices.into_iter().map(|idx| {
+            let context_opt = call_graph.edges_directed(idx, Direction::Outgoing)
+                .into_iter()
+                .map(|e| e.weight().clone())
+                .next();
+            match context_opt {
+                Some(context) => context,
+                None => {
+                    radeco_warn!("No CallContextInfo found @ {:}", idx);
+                    CallContextInfo {
+                        map: Vec::new(),
+                        csite_node: idx,
+                        csite: *call_graph.node_weight(idx).unwrap_or(&0),
+                    }
+                },
+            }
         }).collect::<Vec<_>>()
     }
 

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -1090,6 +1090,10 @@ impl RadecoFunction {
         &self.datarefs
     }
 
+    pub fn locals(&self) -> &VarBindings {
+        unimplemented!()
+    }
+
     pub fn args(&self) -> &VarBindings {
         unimplemented!()
     }

--- a/src/middle/ssa/memoryssa.rs
+++ b/src/middle/ssa/memoryssa.rs
@@ -148,7 +148,7 @@ impl<'a, I, T> MemorySSA<'a, I, T>
     pub fn gather_variables(&mut self,
                         datafers: &Vec<u64>,
                         locals: &Vec<LVarInfo>,
-                        callrefs: &CallContextInfo) {
+                        callrefs: &Vec<NodeIndex>) {
         radeco_trace!("MemorrySSA|Get datafers: {:?}", datafers);
         // datafers is coming from RadecoFunctoin::datafers
         let mut gvars: Vec<VariableType> 
@@ -170,8 +170,8 @@ impl<'a, I, T> MemorySSA<'a, I, T>
         radeco_trace!("MemorrySSA|Get callrefs: {:?}", callrefs);
         // callrefs is coming from RadecoFunctoin::call_ctx::ssa_ref
         let mut evars: Vec<VariableType>
-            = callrefs.map.clone().into_iter()
-                        .map(|(x, _)| VariableType::Extra(x))
+            = callrefs.clone().into_iter()
+                        .map(|x| VariableType::Extra(x))
                         .collect();
         self.variables.append(&mut evars);
 


### PR DESCRIPTION
- Duplicated containers (`frontend::containers`) are removed from most of files.
- FnRef is replaced with u64 (function address) in `analysis::interproc`.
- To fix analysis, the procedure of memoryssa in minidec is commented out.